### PR TITLE
make service nodeport configurable

### DIFF
--- a/deploy/kubernetes/helm/spark-history-mcp/templates/service.yaml
+++ b/deploy/kubernetes/helm/spark-history-mcp/templates/service.yaml
@@ -16,5 +16,8 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "spark-history-mcp.selectorLabels" . | nindent 4 }}

--- a/deploy/kubernetes/helm/spark-history-mcp/tests/service_test.yaml
+++ b/deploy/kubernetes/helm/spark-history-mcp/tests/service_test.yaml
@@ -1,0 +1,63 @@
+suite: test service
+templates:
+  - service.yaml
+tests:
+  - it: should create a service with the correct name
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spark-history-mcp
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
+  - it: should set the correct service type
+    set:
+      service.type: ClusterIP
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+
+  - it: should set the correct port configuration
+    set:
+      service.port: 8080
+      service.targetPort: http
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.ports[0].protocol
+          value: TCP
+      - equal:
+          path: spec.ports[0].name
+          value: http
+
+  - it: should set nodePort when service type is NodePort
+    set:
+      service.type: NodePort
+      service.nodePort: 31888
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+      - equal:
+          path: spec.ports[0].nodePort
+          value: 31888
+
+  - it: should not set nodePort when service type is ClusterIP
+    set:
+      service.type: ClusterIP
+      service.nodePort: 31888
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - notExists:
+          path: spec.ports[0].nodePort

--- a/deploy/kubernetes/helm/spark-history-mcp/values.yaml
+++ b/deploy/kubernetes/helm/spark-history-mcp/values.yaml
@@ -40,6 +40,7 @@ service:
   type: ClusterIP
   port: 18888
   targetPort: http
+  # nodePort: 31888  # Uncomment and set when service.type is NodePort
   annotations: {}
 
 # Ingress configuration


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This makes nodeport configurable in the helm chart. It's useful for local testing.
