### PR TITLE
configurable configuration file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,18 +94,13 @@ python3 -m spark_history_mcp.core.main
 # Deactivate venv
 deactivate
 ```
-
-
-### 📊 Sample Data
-The repository includes real Spark event logs for testing:
-- `spark-bcec39f6201b42b9925124595baad260` - ✅ Successful ETL job
-- `spark-110be3a8424d4a2789cb88134418217b` - 🔄 Data processing job
-- `spark-cc4d115f011443d787f03a71a476a745` - 📈 Multi-stage analytics job
-
-See **[TESTING.md](TESTING.md)** for using them.
-
 ### ⚙️ Server Configuration
 Edit `config.yaml` for your Spark History Server:
+
+**Config File Options:**
+- Command line: `--config /path/to/config.yaml` or `-c /path/to/config.yaml`
+- Environment variable: `SHS_MCP_CONFIG=/path/to/config.yaml`
+- Default: `./config.yaml`
 ```yaml
 servers:
   local:
@@ -120,6 +115,15 @@ mcp:
   port: "18888"
   debug: true
 ```
+
+
+### 📊 Sample Data
+The repository includes real Spark event logs for testing:
+- `spark-bcec39f6201b42b9925124595baad260` - ✅ Successful ETL job
+- `spark-110be3a8424d4a2789cb88134418217b` - 🔄 Data processing job
+- `spark-cc4d115f011443d787f03a71a476a745` - 📈 Multi-stage analytics job
+
+See **[TESTING.md](TESTING.md)** for using them.
 
 ## 📸 Screenshots
 

--- a/src/spark_history_mcp/core/main.py
+++ b/src/spark_history_mcp/core/main.py
@@ -1,7 +1,9 @@
 """Main entry point for Spark History Server MCP."""
 
+import argparse
 import json
 import logging
+import os
 import sys
 
 from spark_history_mcp.config.config import Config
@@ -16,9 +18,19 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Main entry point."""
+    parser = argparse.ArgumentParser(description="Spark History Server MCP")
+    parser.add_argument(
+        "--config",
+        "-c",
+        default=os.getenv("SHS_MCP_CONFIG", "config.yaml"),
+        help="Path to config file (default: config.yaml, env: SHS_MCP_CONFIG)",
+    )
+    args = parser.parse_args()
+
     try:
         logger.info("Starting Spark History Server MCP...")
-        config = Config.from_file("config.yaml")
+        logger.info(f"Using config file: {args.config}")
+        config = Config.from_file(args.config)
         if config.mcp.debug:
             logger.setLevel(logging.DEBUG)
         logger.debug(json.dumps(json.loads(config.model_dump_json()), indent=4))


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

### Background
The config file path was hardcoded as "config.yaml" in main.py, making it difficult to use different configurations for different environments or deployments.

### Changes
• Added command line argument support: --config / -c
• Added environment variable support: SHS_MCP_CONFIG
• Updated README with configuration options

### Usage
```bash
# Command line
python main.py --config /path/to/prod-config.yaml

# Environment variable
SHS_MCP_CONFIG=/path/to/staging-config.yaml python main.py
```
Priority: CLI argument > environment variable > default

## 🎯 Type of Change
<!-- Mark with [x] -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)


fixes: #112