### PR TITLE
Make include_plan_description configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ servers:
     auth:  # optional
       username: "user"
       password: "pass"
+    include_plan_description: false  # optional, whether to include SQL execution plans by default (default: false)
 mcp:
   transports:
     - streamable-http # streamable-http or stdio.
@@ -185,7 +186,7 @@ The MCP server provides **18 specialized tools** organized by analysis patterns.
 *SQL performance analysis and execution plan comparison*
 | 🔧 Tool | 📝 Description |
 |---------|----------------|
-| `list_slowest_sql_queries` | 🐌 Get the top N slowest SQL queries for an application with detailed execution metrics |
+| `list_slowest_sql_queries` | 🐌 Get the top N slowest SQL queries for an application with detailed execution metrics and optional plan descriptions |
 | `compare_sql_execution_plans` | 🔍 Compare SQL execution plans between two Spark jobs, analyzing logical/physical plans and execution metrics |
 
 ### 🚨 Performance & Bottleneck Analysis
@@ -302,6 +303,7 @@ SHS_SERVERS_*_AUTH_TOKEN - Token for a specific server
 SHS_SERVERS_*_VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
 SHS_SERVERS_*_TIMEOUT - HTTP request timeout in seconds for a specific server (default: 30)
 SHS_SERVERS_*_EMR_CLUSTER_ARN - EMR cluster ARN for a specific server
+SHS_SERVERS_*_INCLUDE_PLAN_DESCRIPTION - Whether to include SQL execution plans by default for a specific server (true/false, default: false)
 ```
 
 ## 🤖 AI Agent Integration

--- a/src/spark_history_mcp/config/config.py
+++ b/src/spark_history_mcp/config/config.py
@@ -28,6 +28,7 @@ class ServerConfig(BaseSettings):
     emr_cluster_arn: Optional[str] = None  # EMR specific field
     use_proxy: bool = False
     timeout: int = 30  # HTTP request timeout in seconds
+    include_plan_description: bool = False
 
 
 class McpConfig(BaseSettings):

--- a/src/spark_history_mcp/config/config.py
+++ b/src/spark_history_mcp/config/config.py
@@ -28,7 +28,7 @@ class ServerConfig(BaseSettings):
     emr_cluster_arn: Optional[str] = None  # EMR specific field
     use_proxy: bool = False
     timeout: int = 30  # HTTP request timeout in seconds
-    include_plan_description: bool = False
+    include_plan_description: Optional[bool] = None
 
 
 class McpConfig(BaseSettings):

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -944,9 +944,11 @@ def list_slowest_sql_queries(
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
-    # Use server config if include_plan_description not explicitly provided
-    if include_plan_description is None:
+    # Config takes priority: if config is set (True/False), use it; otherwise default to True
+    if client.config.include_plan_description is not None:
         include_plan_description = client.config.include_plan_description
+    else:
+        include_plan_description = True
 
     all_executions: List[ExecutionData] = []
     offset = 0

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -922,7 +922,7 @@ def list_slowest_sql_queries(
     top_n: int = 1,
     page_size: int = 100,
     include_running: bool = False,
-    include_plan_description: bool = True,
+    include_plan_description: Optional[bool] = None,
     plan_description_max_length: int = 2000,
 ) -> List[SqlQuerySummary]:
     """
@@ -935,7 +935,7 @@ def list_slowest_sql_queries(
         top_n: Number of slowest queries to return (default: 1)
         page_size: Number of executions to fetch per page (default: 100)
         include_running: Whether to include running queries (default: False)
-        include_plan_description: Whether to include execution plans (default: True)
+        include_plan_description: Whether to include execution plans (uses server config if not specified)
         plan_description_max_length: Max characters for plan description (default: 1500)
 
     Returns:
@@ -943,6 +943,10 @@ def list_slowest_sql_queries(
     """
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
+
+    # Use server config if include_plan_description not explicitly provided
+    if include_plan_description is None:
+        include_plan_description = client.config.include_plan_description
 
     all_executions: List[ExecutionData] = []
     offset = 0

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1127,7 +1127,7 @@ class TestTools(unittest.TestCase):
     def test_list_slowest_sql_queries_explicit_override_server_config(
         self, mock_get_client
     ):
-        """Test that explicit include_plan_description parameter overrides server config"""
+        """Test that server config overrides parameter when config is set"""
         # Setup mock client with server config set to False
         mock_client = MagicMock()
         server_config = ServerConfig(
@@ -1150,11 +1150,11 @@ class TestTools(unittest.TestCase):
         mock_client.get_sql_list.return_value = [sql]
         mock_get_client.return_value = mock_client
 
-        # Call function with explicit include_plan_description=True (should override server config)
+        # Call function with explicit include_plan_description=True (config should override to False)
         result = list_slowest_sql_queries(
             "spark-app-123", include_plan_description=True
         )
 
-        # Verify plan description is included despite server config being False
+        # Verify plan description is NOT included because server config is False
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].plan_description, "Sample plan description")
+        self.assertEqual(result[0].plan_description, "")


### PR DESCRIPTION
Make include_plan_description configurable 

# 🔄 Pull Request

## 📝 Description
Make include_plan_description configurable, so that it is possible to mask the plan description optionally. This is useful for spark-history-server that contains plan with sensitive data. 

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
# Example:
# task test
# npx @modelcontextprotocol/inspector uv run -m spark_history_mcp.core.main
```

## 🛠️ New Tools Added (if applicable)
<!-- For new MCP tools -->
- **Tool Name**: `new_tool_name`
- **Purpose**: What it does
- **Usage**: Example parameters

## 📸 Screenshots (if applicable)
<!-- For UI changes or new tools, include MCP Inspector screenshots -->

## ✅ Checklist
- [x] 🔍 Code follows project style guidelines
- [x] 🧪 Added tests for new functionality
- [x] 📖 Updated documentation (README, TESTING.md, etc.)
- [x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md (if significant change)

## 📚 Related Issues
<!-- Link any related issues -->
Fixes #(issue number)
Related to #(issue number)

## 🤔 Additional Context
<!-- Add any additional context, screenshots, or notes -->

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
