### PR TITLE
fix: Add default values to ThreadStackTrace for Spark 3.x compatibility

### DIFF
--- a/src/spark_history_mcp/models/spark_types.py
+++ b/src/spark_history_mcp/models/spark_types.py
@@ -866,14 +866,14 @@ class ThreadStackTrace(BaseModel):
     blocked_by_thread_id: Optional[int] = Field(None, alias="blockedByThreadId")
     blocked_by_lock: Optional[str] = Field(None, alias="blockedByLock")
     holding_locks: Sequence[str] = Field([], alias="holdingLocks")  # deprecated
-    synchronizers: Sequence[str]
-    monitors: Sequence[str]
+    synchronizers: Sequence[str] = Field(default_factory=list, alias="synchronizers")
+    monitors: Sequence[str] = Field(default_factory=list, alias="monitors")
     lock_name: Optional[str] = Field(None, alias="lockName")
     lock_owner_name: Optional[str] = Field(None, alias="lockOwnerName")
-    suspended: bool
+    suspended: bool = Field(False, alias="suspended")
     in_native: Optional[bool] = Field(None, alias="inNative")
     is_daemon: Optional[bool] = Field(None, alias="isDaemon")
-    priority: int
+    priority: int = Field(0, alias="priority")
 
     model_config = ConfigDict(populate_by_name=True, arbitrary_types_allowed=True)
 

--- a/tests/unit/test_spark_types.py
+++ b/tests/unit/test_spark_types.py
@@ -1,0 +1,88 @@
+import unittest
+
+from spark_history_mcp.models.spark_types import ThreadStackTrace
+
+
+class TestThreadStackTrace(unittest.TestCase):
+    """Test ThreadStackTrace model handles missing fields from older Spark versions."""
+
+    def test_full_response_spark4(self):
+        """Spark 4.x returns all fields including synchronizers, monitors, priority."""
+        data = {
+            "threadId": 1,
+            "threadName": "main",
+            "threadState": "RUNNABLE",
+            "stackTrace": None,
+            "blockedByThreadId": None,
+            "blockedByLock": "",
+            "holdingLocks": [],
+            "synchronizers": [
+                "java.util.concurrent.locks.ReentrantLock$NonfairSync@abc"
+            ],
+            "monitors": ["java.lang.Object@def"],
+            "lockName": None,
+            "lockOwnerName": None,
+            "suspended": False,
+            "inNative": False,
+            "isDaemon": True,
+            "priority": 5,
+        }
+        trace = ThreadStackTrace.model_validate(data)
+        self.assertEqual(trace.thread_id, 1)
+        self.assertEqual(trace.thread_name, "main")
+        self.assertEqual(len(trace.synchronizers), 1)
+        self.assertEqual(len(trace.monitors), 1)
+        self.assertFalse(trace.suspended)
+        self.assertEqual(trace.priority, 5)
+        self.assertTrue(trace.is_daemon)
+
+    def test_minimal_response_spark3(self):
+        """Spark 3.x may omit synchronizers, monitors, isDaemon, and priority."""
+        data = {
+            "threadId": 42,
+            "threadName": "executor-thread-1",
+            "threadState": "WAITING",
+            "stackTrace": None,
+            "blockedByThreadId": None,
+            "blockedByLock": "",
+            "holdingLocks": [],
+            "lockName": None,
+            "lockOwnerName": None,
+            "inNative": False,
+        }
+        trace = ThreadStackTrace.model_validate(data)
+        self.assertEqual(trace.thread_id, 42)
+        self.assertEqual(trace.thread_name, "executor-thread-1")
+        self.assertEqual(trace.synchronizers, [])
+        self.assertEqual(trace.monitors, [])
+        self.assertFalse(trace.suspended)
+        self.assertEqual(trace.priority, 0)
+        self.assertIsNone(trace.is_daemon)
+
+    def test_partial_response(self):
+        """Some fields present, some missing - mixed Spark version scenario."""
+        data = {
+            "threadId": 10,
+            "threadName": "shuffle-server",
+            "threadState": "TIMED_WAITING",
+            "stackTrace": None,
+            "blockedByThreadId": None,
+            "blockedByLock": "",
+            "holdingLocks": [],
+            "synchronizers": [],
+            "lockName": "java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@1234",
+            "lockOwnerName": None,
+            "suspended": True,
+            "inNative": True,
+            "isDaemon": False,
+        }
+        trace = ThreadStackTrace.model_validate(data)
+        self.assertEqual(trace.priority, 0)
+        self.assertTrue(trace.suspended)
+        self.assertTrue(trace.in_native)
+        self.assertFalse(trace.is_daemon)
+        self.assertEqual(trace.synchronizers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

The `ThreadStackTrace` model has several fields (`synchronizers`, `monitors`, `suspended`, `priority`) that were introduced in **Spark 4.0.0** ([SPARK-44893](https://issues.apache.org/jira/browse/SPARK-44893), [SPARK-44895](https://issues.apache.org/jira/browse/SPARK-44895)). When connecting to a **Spark 3.x** History Server, these fields are absent from the REST API JSON response, causing **Pydantic validation errors** and preventing thread dump data from being parsed.

This change adds sensible default values so the model works seamlessly across both Spark 3.x and 4.x:

| Field | Type | Default | Reason |
|-------|------|---------|--------|
| `synchronizers` | `Sequence[str]` | `[]` | Not present in Spark 3.x (replaced `holdingLocks` in 4.0) |
| `monitors` | `Sequence[str]` | `[]` | Not present in Spark 3.x (replaced `holdingLocks` in 4.0) |
| `suspended` | `bool` | `False` | May be omitted in some responses |
| `priority` | `int` | `0` | Added in Spark 4.0.0 via SPARK-44895 |

No existing behavior is changed — when these fields are present in the API response, they are parsed as before.

## 🎯 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
- [x] ✅ All existing tests pass (`uv run pytest tests/unit/ -v` — 55 tests passed)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
uv run pytest tests/unit/ -v
uv run ruff check src/spark_history_mcp/models/spark_types.py tests/unit/test_spark_types.py
uv run ruff format --check src/spark_history_mcp/models/spark_types.py tests/unit/test_spark_types.py
```

### New Test Cases
- `test_full_response_spark4` — Validates parsing with all fields present (Spark 4.x response)
- `test_minimal_response_spark3` — Validates parsing with omitted fields (Spark 3.x response)
- `test_partial_response` — Validates parsing with a mix of present/absent fields

## 🛠️ New Tools Added
N/A

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] 🔍 Code follows project style guidelines
- [x] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.) — N/A for this bug fix
- [x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md — N/A for minor fix

## 📚 Related Issues
Related to [SPARK-44893](https://issues.apache.org/jira/browse/SPARK-44893) — ThreadInfo improvements for monitoring APIs
Related to [SPARK-44895](https://issues.apache.org/jira/browse/SPARK-44895) — Considering 'daemon', 'priority' from higher JDKs for ThreadStackTrace class

## 🤔 Additional Context
This is a backward-compatible fix. The default values are chosen to be safe no-ops: empty lists for lock/monitor collections, `False` for suspension state, and `0` for priority. When a Spark 4.x server provides these fields, they are still parsed normally.