### PR TITLE
feat: Add get_sql_execution MCP tool

### DIFF
--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -1017,6 +1017,47 @@ def list_slowest_sql_queries(
 
 
 @mcp.tool()
+def get_sql_execution(
+    app_id: str,
+    execution_id: int,
+    server: Optional[str] = None,
+    attempt_id: Optional[str] = None,
+    details: bool = True,
+    plan_description: bool = True,
+) -> ExecutionData:
+    """
+    Get detailed information about a specific SQL execution.
+
+    Retrieves comprehensive details of a single SQL execution including its
+    execution plan, associated jobs, metrics, and node-level statistics.
+    This is useful for deep-diving into a specific query's performance after
+    identifying it via list_slowest_sql_queries.
+
+    Args:
+        app_id: The Spark application ID
+        execution_id: The SQL execution ID
+        server: Optional server name to use (uses default if not specified)
+        attempt_id: Optional application attempt ID
+        details: Whether to include execution details (default: True)
+        plan_description: Whether to include plan description (default: True)
+
+    Returns:
+        ExecutionData object containing SQL execution details including
+        status, duration, associated job IDs, and execution plan nodes/edges
+    """
+    ctx = mcp.get_context()
+    client = get_client_or_default(ctx, server, app_id)
+
+    return client.get_sql_execution(
+        app_id=app_id,
+        execution_id=execution_id,
+        attempt_id=attempt_id,
+        details=details,
+        plan_description=plan_description,
+    )
+
+
+@mcp.tool()
 def get_job_bottlenecks(
     app_id: str, server: Optional[str] = None, top_n: int = 5
 ) -> Dict[str, Any]:

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -14,6 +14,7 @@ from spark_history_mcp.models.spark_types import (
 from spark_history_mcp.tools.tools import (
     get_application,
     get_client_or_default,
+    get_sql_execution,
     get_stage,
     get_stage_task_summary,
     list_applications,
@@ -1158,3 +1159,63 @@ class TestTools(unittest.TestCase):
         # Verify plan description is NOT included because server config is False
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].plan_description, "")
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_success(self, mock_get_client):
+        """Test get_sql_execution returns execution details"""
+        mock_client = MagicMock()
+        expected = MagicMock(spec=ExecutionData)
+        expected.id = 42
+        expected.status = "COMPLETED"
+        expected.duration = 12345
+        expected.description = "SELECT * FROM table"
+        mock_client.get_sql_execution.return_value = expected
+        mock_get_client.return_value = mock_client
+
+        result = get_sql_execution("spark-app-123", execution_id=42)
+
+        self.assertEqual(result.id, 42)
+        self.assertEqual(result.status, "COMPLETED")
+        mock_client.get_sql_execution.assert_called_once_with(
+            app_id="spark-app-123",
+            execution_id=42,
+            attempt_id=None,
+            details=True,
+            plan_description=True,
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_with_attempt_id(self, mock_get_client):
+        """Test get_sql_execution with attempt_id"""
+        mock_client = MagicMock()
+        expected = MagicMock(spec=ExecutionData)
+        expected.id = 10
+        mock_client.get_sql_execution.return_value = expected
+        mock_get_client.return_value = mock_client
+
+        result = get_sql_execution(
+            "spark-app-123", execution_id=10, attempt_id="1", details=False
+        )
+
+        self.assertEqual(result.id, 10)
+        mock_client.get_sql_execution.assert_called_once_with(
+            app_id="spark-app-123",
+            execution_id=10,
+            attempt_id="1",
+            details=False,
+            plan_description=True,
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_not_found(self, mock_get_client):
+        """Test get_sql_execution raises when execution not found"""
+        mock_client = MagicMock()
+        mock_client.get_sql_execution.side_effect = Exception(
+            "SQL execution 999 not found"
+        )
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(Exception) as ctx:
+            get_sql_execution("spark-app-123", execution_id=999)
+
+        self.assertIn("999", str(ctx.exception))


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This PR exposes the existing `SparkRestClient.get_sql_execution()` method as a standalone MCP tool. Currently, `get_sql_execution()` is only used internally by `compare_sql_execution_plans`, but there is no way for AI agents to inspect a **single** SQL execution directly.

### Motivation

The typical SQL debugging workflow is:
1. Use `list_slowest_sql_queries` to identify slow queries
2. **❓ Gap: no way to get details of a specific execution by ID**
3. Use `compare_sql_execution_plans` to compare two executions

This new tool fills step 2, allowing agents to deep-dive into a specific query's execution plan, associated jobs, metrics, and node-level statistics.

### Example Usage

```python
result = get_sql_execution(
    app_id="application_123",
    execution_id=42,
    details=True,
    plan_description=True
)
# Returns: ExecutionData with status, duration, job IDs, plan nodes/edges
```

## 🎯 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
- [x] ✅ All existing tests pass (`uv run pytest tests/unit/ -v` — 58 tests passed)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
uv run pytest tests/unit/ -v
uv run ruff check src/spark_history_mcp/tools/tools.py tests/unit/test_tools.py
uv run ruff format --check src/spark_history_mcp/tools/tools.py tests/unit/test_tools.py
```

### New Test Cases
- `test_get_sql_execution_success` — Verifies tool returns execution details and passes correct parameters to client
- `test_get_sql_execution_with_attempt_id` — Verifies attempt_id and details=False are forwarded correctly
- `test_get_sql_execution_not_found` — Verifies proper error propagation when execution ID doesn't exist

## 🛠️ New Tools Added
- **Tool Name**: `get_sql_execution`
- **Purpose**: Get detailed information about a specific SQL execution by ID
- **Usage**:
  - `app_id` (required): The Spark application ID
  - `execution_id` (required): The SQL execution ID
  - `server` (optional): Server name to use
  - `attempt_id` (optional): Application attempt ID
  - `details` (optional, default: True): Include execution details
  - `plan_description` (optional, default: True): Include plan description
- **Returns**: `ExecutionData` object with status, duration, job IDs, plan nodes/edges

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] 🔍 Code follows project style guidelines
- [x] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.) — N/A, tool is self-documenting via docstring
- [x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md — N/A
- [x] 📖 Tool follows existing patterns (uses `get_client_or_default`, MCP context)

## 📚 Related Issues
Related to the SQL debugging workflow gap — no existing issue, but complements `list_slowest_sql_queries` and `compare_sql_execution_plans`.

## 🤔 Additional Context
The underlying `get_sql_execution()` method already exists in `SparkRestClient` and is battle-tested by `compare_sql_execution_plans`. This PR simply wraps it as a first-class MCP tool with proper documentation and tests.