### PR TITLE
feat: add client-side pagination to list tools

### DIFF
--- a/src/spark_history_mcp/api/spark_client.py
+++ b/src/spark_history_mcp/api/spark_client.py
@@ -257,7 +257,11 @@ class SparkRestClient:
         return self._parse_model(data, ApplicationAttemptInfo)
 
     def list_jobs(
-        self, app_id: str, status: Optional[List[JobExecutionStatus]] = None
+        self,
+        app_id: str,
+        status: Optional[List[JobExecutionStatus]] = None,
+        offset: int = 0,
+        length: Optional[int] = None,
     ) -> List[JobData]:
         """
         Get a list of all jobs for an application.
@@ -265,6 +269,8 @@ class SparkRestClient:
         Args:
             app_id: The application ID
             status: Filter by job status
+            offset: Number of items to skip from the start (client-side)
+            length: Maximum number of items to return (client-side, None = all)
 
         Returns:
             List of JobData objects
@@ -274,7 +280,10 @@ class SparkRestClient:
             params["status"] = [s.value for s in status]
 
         data = self._get(f"applications/{app_id}/jobs", params)
-        return self._parse_model_list(data, JobData)
+        jobs = self._parse_model_list(data, JobData)
+        if length is not None:
+            return jobs[offset : offset + length]
+        return jobs[offset:] if offset else jobs
 
     def get_job(self, app_id: str, job_id: int) -> JobData:
         """
@@ -298,6 +307,8 @@ class SparkRestClient:
         with_summaries: bool = False,
         quantiles: str = "0.05, 0.25, 0.5, 0.75, 0.95",
         task_status: Optional[List[TaskStatus]] = None,
+        offset: int = 0,
+        length: Optional[int] = None,
     ) -> List[StageData]:
         """
         Get a list of all stages for an application.
@@ -309,6 +320,8 @@ class SparkRestClient:
             with_summaries: Whether to include summary metrics
             quantiles: Comma-separated list of quantiles to use for summary metrics
             task_status: Filter by task status (only takes effect when details=true)
+            offset: Number of items to skip from the start (client-side)
+            length: Maximum number of items to return (client-side, None = all)
 
         Returns:
             List of StageData objects
@@ -321,12 +334,14 @@ class SparkRestClient:
 
         if status:
             params["status"] = [s.value for s in status]
-        # taskStatus parameter only takes effect when details=true
         if task_status and details:
             params["taskStatus"] = [s.value for s in task_status]
 
         data = self._get(f"applications/{app_id}/stages", params)
-        return self._parse_model_list(data, StageData)
+        stages = self._parse_model_list(data, StageData)
+        if length is not None:
+            return stages[offset : offset + length]
+        return stages[offset:] if offset else stages
 
     def list_stage_attempts(
         self,
@@ -462,31 +477,51 @@ class SparkRestClient:
         )
         return self._parse_model_list(data, TaskData)
 
-    def list_executors(self, app_id: str) -> List[ExecutorSummary]:
+    def list_executors(
+        self,
+        app_id: str,
+        offset: int = 0,
+        length: Optional[int] = None,
+    ) -> List[ExecutorSummary]:
         """
         Get a list of all executors for an application.
 
         Args:
             app_id: The application ID
+            offset: Number of items to skip from the start (client-side)
+            length: Maximum number of items to return (client-side, None = all)
 
         Returns:
             List of ExecutorSummary objects
         """
         data = self._get(f"applications/{app_id}/executors")
-        return self._parse_model_list(data, ExecutorSummary)
+        executors = self._parse_model_list(data, ExecutorSummary)
+        if length is not None:
+            return executors[offset : offset + length]
+        return executors[offset:] if offset else executors
 
-    def list_all_executors(self, app_id: str) -> List[ExecutorSummary]:
+    def list_all_executors(
+        self,
+        app_id: str,
+        offset: int = 0,
+        length: Optional[int] = None,
+    ) -> List[ExecutorSummary]:
         """
         Get a list of all executors (active and inactive) for an application.
 
         Args:
             app_id: The application ID
+            offset: Number of items to skip from the start (client-side)
+            length: Maximum number of items to return (client-side, None = all)
 
         Returns:
             List of ExecutorSummary objects
         """
         data = self._get(f"applications/{app_id}/allexecutors")
-        return self._parse_model_list(data, ExecutorSummary)
+        executors = self._parse_model_list(data, ExecutorSummary)
+        if length is not None:
+            return executors[offset : offset + length]
+        return executors[offset:] if offset else executors
 
     def list_executor_thread_dump(
         self, app_id: str, executor_id: str

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -153,15 +153,24 @@ def get_application(app_id: str, server: Optional[str] = None) -> ApplicationInf
 
 @mcp.tool()
 def list_jobs(
-    app_id: str, server: Optional[str] = None, status: Optional[list[str]] = None
+    app_id: str,
+    server: Optional[str] = None,
+    status: Optional[list[str]] = None,
+    offset: int = 0,
+    length: Optional[int] = None,
 ) -> list:
     """
-    Get a list of all jobs for a Spark application.
+    Get a list of jobs for a Spark application.
+
+    Returns job metadata including ID, name, status, submission/completion times,
+    and task counts. Supports client-side pagination to limit response size.
 
     Args:
         app_id: The Spark application ID
         server: Optional server name to use (uses default if not specified)
         status: Optional list of job status values to filter by
+        offset: Number of jobs to skip from the start (default: 0)
+        length: Maximum number of jobs to return (default: None, returns all)
 
     Returns:
         List of JobData objects for the application
@@ -169,12 +178,18 @@ def list_jobs(
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
-    # Convert string status values to JobExecutionStatus enum if provided
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if length is not None and length < 0:
+        raise ValueError("length must be non-negative")
+
     job_statuses = None
     if status:
         job_statuses = [JobExecutionStatus.from_string(s) for s in status]
 
-    return client.list_jobs(app_id=app_id, status=job_statuses)
+    return client.list_jobs(
+        app_id=app_id, status=job_statuses, offset=offset, length=length
+    )
 
 
 @mcp.tool()
@@ -228,18 +243,23 @@ def list_stages(
     server: Optional[str] = None,
     status: Optional[list[str]] = None,
     with_summaries: bool = False,
+    offset: int = 0,
+    length: Optional[int] = None,
 ) -> list:
     """
-    Get a list of all stages for a Spark application.
+    Get a list of stages for a Spark application.
 
     Retrieves information about stages in a Spark application with options to filter
-    by status and include additional details and summary metrics.
+    by status and include additional details and summary metrics. Supports client-side
+    pagination to limit response size.
 
     Args:
         app_id: The Spark application ID
         server: Optional server name to use (uses default if not specified)
         status: Optional list of stage status values to filter by
         with_summaries: Whether to include summary metrics in the response
+        offset: Number of stages to skip from the start (default: 0)
+        length: Maximum number of stages to return (default: None, returns all)
 
     Returns:
         List of StageData objects for the application
@@ -247,7 +267,11 @@ def list_stages(
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
-    # Convert string status values to StageStatus enum if provided
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if length is not None and length < 0:
+        raise ValueError("length must be non-negative")
+
     stage_statuses = None
     if status:
         stage_statuses = [StageStatus.from_string(s) for s in status]
@@ -256,6 +280,8 @@ def list_stages(
         app_id=app_id,
         status=stage_statuses,
         with_summaries=with_summaries,
+        offset=offset,
+        length=length,
     )
 
 
@@ -391,18 +417,25 @@ def get_environment(app_id: str, server: Optional[str] = None):
 
 @mcp.tool()
 def list_executors(
-    app_id: str, server: Optional[str] = None, include_inactive: bool = False
+    app_id: str,
+    server: Optional[str] = None,
+    include_inactive: bool = False,
+    offset: int = 0,
+    length: Optional[int] = None,
 ):
     """
     Get executor information for a Spark application.
 
     Retrieves a list of executors (active by default) for the specified Spark application
-    with their resource allocation, task statistics, and performance metrics.
+    with their resource allocation, task statistics, and performance metrics. Supports
+    client-side pagination to limit response size.
 
     Args:
         app_id: The Spark application ID
         server: Optional server name to use (uses default if not specified)
         include_inactive: Whether to include inactive executors (default: False)
+        offset: Number of executors to skip from the start (default: 0)
+        length: Maximum number of executors to return (default: None, returns all)
 
     Returns:
         List of ExecutorSummary objects containing executor information
@@ -410,10 +443,15 @@ def list_executors(
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
+    if offset < 0:
+        raise ValueError("offset must be non-negative")
+    if length is not None and length < 0:
+        raise ValueError("length must be non-negative")
+
     if include_inactive:
-        return client.list_all_executors(app_id=app_id)
+        return client.list_all_executors(app_id=app_id, offset=offset, length=length)
     else:
-        return client.list_executors(app_id=app_id)
+        return client.list_executors(app_id=app_id, offset=offset, length=length)
 
 
 @mcp.tool()

--- a/tests/unit/test_spark_client.py
+++ b/tests/unit/test_spark_client.py
@@ -238,3 +238,103 @@ class TestSparkClient(unittest.TestCase):
                 expected_url,
                 f"Failed to correctly modify URL.\nInput: {input_url}\nExpected: {expected_url}\nGot: {modified_url}",
             )
+
+    @patch("spark_history_mcp.api.spark_client.requests.get")
+    def test_list_jobs_pagination(self, mock_get):
+        """Test client-side pagination for list_jobs"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "jobId": i,
+                "name": f"job-{i}",
+                "status": "SUCCEEDED",
+                "stageIds": [],
+                "numTasks": 10,
+                "numActiveTasks": 0,
+                "numCompletedTasks": 10,
+                "numSkippedTasks": 0,
+                "numFailedTasks": 0,
+                "numKilledTasks": 0,
+                "numCompletedIndices": 10,
+                "numActiveStages": 0,
+                "numCompletedStages": 1,
+                "numSkippedStages": 0,
+                "numFailedStages": 0,
+                "killedTasksSummary": {},
+            }
+            for i in range(5)
+        ]
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        # No pagination — returns all
+        all_jobs = self.client.list_jobs("app-123")
+        self.assertEqual(len(all_jobs), 5)
+
+        # With offset
+        jobs = self.client.list_jobs("app-123", offset=2)
+        self.assertEqual(len(jobs), 3)
+        self.assertEqual(jobs[0].job_id, 2)
+
+        # With offset + length
+        jobs = self.client.list_jobs("app-123", offset=1, length=2)
+        self.assertEqual(len(jobs), 2)
+        self.assertEqual(jobs[0].job_id, 1)
+        self.assertEqual(jobs[1].job_id, 2)
+
+        # Offset beyond range
+        jobs = self.client.list_jobs("app-123", offset=10)
+        self.assertEqual(len(jobs), 0)
+
+    @patch("spark_history_mcp.api.spark_client.requests.get")
+    def test_list_executors_pagination(self, mock_get):
+        """Test client-side pagination for list_executors"""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [
+            {
+                "id": str(i),
+                "hostPort": f"host-{i}:1234",
+                "isActive": True,
+                "rddBlocks": 0,
+                "memoryUsed": 0,
+                "diskUsed": 0,
+                "totalCores": 4,
+                "maxTasks": 4,
+                "activeTasks": 0,
+                "failedTasks": 0,
+                "completedTasks": 100,
+                "totalTasks": 100,
+                "totalDuration": 5000,
+                "totalGCTime": 100,
+                "totalInputBytes": 0,
+                "totalShuffleRead": 0,
+                "totalShuffleWrite": 0,
+                "isBlacklisted": False,
+                "maxMemory": 1000,
+                "addTime": "2023-01-01T00:00:00.000GMT",
+                "executorLogs": {},
+                "blacklistedInStages": [],
+                "attributes": {},
+                "resources": {},
+                "resourceProfileId": 0,
+                "isExcluded": False,
+                "excludedInStages": [],
+            }
+            for i in range(10)
+        ]
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+
+        # No pagination
+        all_executors = self.client.list_executors("app-123")
+        self.assertEqual(len(all_executors), 10)
+
+        # With length only
+        executors = self.client.list_executors("app-123", length=3)
+        self.assertEqual(len(executors), 3)
+        self.assertEqual(executors[0].id, "0")
+
+        # With offset + length
+        executors = self.client.list_executors("app-123", offset=8, length=5)
+        self.assertEqual(len(executors), 2)
+        self.assertEqual(executors[0].id, "8")

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -18,6 +18,7 @@ from spark_history_mcp.tools.tools import (
     get_stage,
     get_stage_task_summary,
     list_applications,
+    list_executors,
     list_jobs,
     list_slowest_jobs,
     list_slowest_sql_queries,
@@ -506,7 +507,7 @@ class TestTools(unittest.TestCase):
         # Verify results
         self.assertEqual(result, mock_jobs)
         mock_client.list_jobs.assert_called_once_with(
-            app_id="spark-app-123", status=None
+            app_id="spark-app-123", status=None, offset=0, length=None
         )
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
@@ -581,7 +582,11 @@ class TestTools(unittest.TestCase):
         # Verify results
         self.assertEqual(result, mock_stages)
         mock_client.list_stages.assert_called_once_with(
-            app_id="spark-app-123", status=None, with_summaries=False
+            app_id="spark-app-123",
+            status=None,
+            with_summaries=False,
+            offset=0,
+            length=None,
         )
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
@@ -623,7 +628,11 @@ class TestTools(unittest.TestCase):
 
         # Verify summaries parameter is passed
         mock_client.list_stages.assert_called_once_with(
-            app_id="spark-app-123", status=None, with_summaries=True
+            app_id="spark-app-123",
+            status=None,
+            with_summaries=True,
+            offset=0,
+            length=None,
         )
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
@@ -1219,3 +1228,90 @@ class TestTools(unittest.TestCase):
             get_sql_execution("spark-app-123", execution_id=999)
 
         self.assertIn("999", str(ctx.exception))
+
+    # Tests for pagination support
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_jobs_with_pagination(self, mock_get_client):
+        """Test list_jobs forwards offset and length to client"""
+        mock_client = MagicMock()
+        mock_client.list_jobs.return_value = [MagicMock(spec=JobData)]
+        mock_get_client.return_value = mock_client
+
+        list_jobs("spark-app-123", offset=5, length=10)
+
+        mock_client.list_jobs.assert_called_once_with(
+            app_id="spark-app-123", status=None, offset=5, length=10
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_jobs_pagination_defaults(self, mock_get_client):
+        """Test list_jobs uses correct defaults (offset=0, length=None)"""
+        mock_client = MagicMock()
+        mock_client.list_jobs.return_value = []
+        mock_get_client.return_value = mock_client
+
+        list_jobs("spark-app-123")
+
+        mock_client.list_jobs.assert_called_once_with(
+            app_id="spark-app-123", status=None, offset=0, length=None
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_jobs_negative_offset_raises(self, mock_get_client):
+        """Test list_jobs rejects negative offset"""
+        mock_get_client.return_value = MagicMock()
+
+        with self.assertRaises(ValueError):
+            list_jobs("spark-app-123", offset=-1)
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_stages_with_pagination(self, mock_get_client):
+        """Test list_stages forwards offset and length to client"""
+        mock_client = MagicMock()
+        mock_client.list_stages.return_value = [MagicMock(spec=StageData)]
+        mock_get_client.return_value = mock_client
+
+        list_stages("spark-app-123", offset=2, length=5)
+
+        mock_client.list_stages.assert_called_once_with(
+            app_id="spark-app-123",
+            status=None,
+            with_summaries=False,
+            offset=2,
+            length=5,
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_stages_negative_length_raises(self, mock_get_client):
+        """Test list_stages rejects negative length"""
+        mock_get_client.return_value = MagicMock()
+
+        with self.assertRaises(ValueError):
+            list_stages("spark-app-123", length=-1)
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_executors_with_pagination(self, mock_get_client):
+        """Test list_executors forwards offset and length to client"""
+        mock_client = MagicMock()
+        mock_client.list_executors.return_value = []
+        mock_get_client.return_value = mock_client
+
+        list_executors("spark-app-123", offset=3, length=10)
+
+        mock_client.list_executors.assert_called_once_with(
+            app_id="spark-app-123", offset=3, length=10
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_executors_inactive_with_pagination(self, mock_get_client):
+        """Test list_executors with include_inactive uses list_all_executors"""
+        mock_client = MagicMock()
+        mock_client.list_all_executors.return_value = []
+        mock_get_client.return_value = mock_client
+
+        list_executors("spark-app-123", include_inactive=True, offset=0, length=20)
+
+        mock_client.list_all_executors.assert_called_once_with(
+            app_id="spark-app-123", offset=0, length=20
+        )


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

Add `offset` and `length` pagination parameters to list tools (`list_jobs`, `list_stages`, `list_executors`) to allow AI agents to control the amount of data returned, preventing context window overflow when applications have many jobs, stages, or executors.

### Motivation

When using MCP tools with LLMs, large Spark applications can return hundreds or thousands of items from list endpoints, consuming significant portions of the model's context window (related: #3, #83). This PR adds lightweight pagination support so that agents can:

1. Fetch a manageable first page (e.g., `offset=0, length=20`)
2. Request subsequent pages as needed
3. Combine pagination with existing filters (status, etc.) for fine-grained control

### Implementation

The Spark REST API does not natively support pagination parameters for job/stage/executor list endpoints, so pagination is implemented client-side:

- **`SparkRestClient` layer**: `list_jobs`, `list_stages`, `list_executors`, and `list_all_executors` accept `offset` (default: 0) and `length` (default: None) parameters, slicing the parsed result list
- **MCP tool layer**: `list_jobs`, `list_stages`, and `list_executors` expose the same parameters with input validation (non-negative offset/length)
- **Backward compatible**: Default values (`offset=0`, `length=None`) return all items, matching existing behavior

## 🎯 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
- [x] ✅ All existing tests pass (`uv run pytest tests/unit/ -v` — 64 tests passed)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
uv run pytest tests/unit/ -v
uv run ruff check src/spark_history_mcp/api/spark_client.py src/spark_history_mcp/tools/tools.py
uv run ruff format --check src/spark_history_mcp/api/spark_client.py src/spark_history_mcp/tools/tools.py
```

### New Test Cases

**Tool layer** (`test_tools.py`):
- `test_list_jobs_with_pagination` — Verifies offset/length forwarded to client
- `test_list_jobs_pagination_defaults` — Verifies default values (offset=0, length=None)
- `test_list_jobs_negative_offset_raises` — Validates negative offset rejected
- `test_list_stages_with_pagination` — Verifies offset/length forwarded to client
- `test_list_stages_negative_length_raises` — Validates negative length rejected
- `test_list_executors_with_pagination` — Verifies pagination for active executors
- `test_list_executors_inactive_with_pagination` — Verifies pagination routes to `list_all_executors`

**Client layer** (`test_spark_client.py`):
- `test_list_jobs_pagination` — End-to-end client-side slicing (offset, length, edge cases)
- `test_list_executors_pagination` — End-to-end client-side slicing for executors

## 🛠️ New Tools Added
N/A — This PR enhances existing tools (`list_jobs`, `list_stages`, `list_executors`) with new optional parameters.

## 📸 Screenshots
N/A

## ✅ Checklist
- [x] 🔍 Code follows project style guidelines
- [x] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.) — N/A, parameters are self-documenting via docstrings
- [x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md — N/A

## 📚 Related Issues
Related to #3 — Too many tools / context window concerns
Related to #83 — Timeout issues with large data returns

## 🤔 Additional Context

### Files Changed
- `src/spark_history_mcp/api/spark_client.py` — add `offset`/`length` to 4 list methods
- `src/spark_history_mcp/tools/tools.py` — add `offset`/`length` to 3 MCP tools with validation
- `tests/unit/test_spark_client.py` — client-side pagination integration tests
- `tests/unit/test_tools.py` — tool-level pagination + validation tests

### Why client-side pagination?
The Spark REST API does not support `offset`/`limit` query parameters for `/applications/{appId}/jobs`, `/stages`, or `/executors` endpoints. Server-side pagination would require upstream Spark changes. Client-side slicing is a pragmatic solution that still significantly reduces token consumption for LLM agents while maintaining full backward compatibility.