### PR TITLE
CLI: add config command with default config values

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,15 @@ Point it at your Spark History Server and start querying:
 ```bash
 shs apps --server http://your-spark-history-server:18080
 shs stages -a <app-id> --sort duration
+
+# Generate a config file to avoid passing --server every time
+shs setup config > config.yaml
+
+# Generate a skill file for coding agents (e.g. Claude Code)
+shs setup skill > ~/.claude/skills/spark-history.md
 ```
 
-See the [CLI documentation](skills/cli/README.md) for full usage.
+See the [CLI documentation](skills/cli/README.md) for full usage, or check out a [real-world example](skills/cli/examples/compare/README.md) of Claude Code comparing two TPC-DS 3TB benchmark runs.
 
 ### MCP Server
 
@@ -147,15 +153,6 @@ mcp:
   port: "18888"
   debug: true
 ```
-
-
-### 📊 Sample Data
-The repository includes real Spark event logs for testing:
-- `spark-bcec39f6201b42b9925124595baad260` - ✅ Successful ETL job
-- `spark-110be3a8424d4a2789cb88134418217b` - 🔄 Data processing job
-- `spark-cc4d115f011443d787f03a71a476a745` - 📈 Multi-stage analytics job
-
-See **[TESTING.md](TESTING.md)** for using them.
 
 ## 📸 Screenshots
 
@@ -346,6 +343,13 @@ SHS_SERVERS_*_INCLUDE_PLAN_DESCRIPTION - Whether to include SQL execution plans 
 | **[Kiro](examples/integrations/kiro/)** | HTTP | IDE integration, code-centric analysis |
 | **[LangGraph](examples/integrations/langgraph/)** | HTTP | Multi-agent workflows |
 | **[Strands Agents](examples/integrations/strands-agents/)** | HTTP | Multi-agent workflows |
+
+> **Tip:** The `shs` CLI can also generate a skill file for coding agents that support tool use:
+> ```bash
+> shs setup skill > ~/.claude/skills/spark-history.md
+> ```
+> This gives agents like Claude Code direct access to Spark History Server queries without the MCP server.
+> See a [real-world example](skills/cli/examples/compare/README.md) of Claude Code using `shs` to compare two TPC-DS 3TB benchmark runs — dispatching subagents in parallel for per-query root cause analysis.
 
 ## 🎯 Example Use Cases
 

--- a/skills/cli/cmd/prime.go
+++ b/skills/cli/cmd/prime.go
@@ -35,6 +35,7 @@ COMMANDS
     --server-a NAME  Server for app A (overrides --server)
     --server-b NAME  Server for app B (overrides --server)
   shs servers                     List configured servers
+  shs setup config                Print a sample config.yaml to get started
   shs version                     CLI + server Spark version
 
 GLOBAL FLAGS
@@ -64,6 +65,7 @@ COMMAND DETAILS
              apps (executors, jobs, stages, aggregate I/O)  stages (stage metrics + task quantiles)
 
 CONFIG FILE
+  Generate a starter config: shs setup config > config.yaml
   Default path: config.yaml (override with -c or SHS_CLI__CONFIG env var).
 
   servers:
@@ -81,7 +83,7 @@ CONFIG FILE
   Fields per server:
     url             Base URL of the Spark History Server (required)
     default         true to use this server when --server is omitted
-    verify_ssl      TLS verification (default: true)
+    verify_ssl      TLS verification (default: false)
     auth.username   Basic auth username
     auth.password   Basic auth password
     auth.token      Bearer token (alternative to username/password)

--- a/skills/cli/cmd/setup.go
+++ b/skills/cli/cmd/setup.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"text/template"
 
+	goyaml "github.com/goccy/go-yaml"
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/config"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +41,59 @@ func newSetupCmd() *cobra.Command {
 		Short: "Print agent skill files to stdout",
 	}
 	cmd.AddCommand(newSetupSkillCmd())
+	cmd.AddCommand(newSetupConfigCmd())
 	return cmd
+}
+
+func newSetupConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config",
+		Short: "Print a sample config.yaml to get started",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out, err := sampleConfig()
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(out)
+			return err
+		},
+	}
+}
+
+// sampleConfig marshals a representative Config struct to YAML so the output
+// automatically reflects any fields added to the structs — no template to
+// keep in sync. Comments are attached via goccy/go-yaml's CommentMap; a
+// missing comment on a new field is harmless, whereas a missing field in a
+// hardcoded template is a silent bug.
+func sampleConfig() ([]byte, error) {
+	cfg := config.Config{
+		Servers: map[string]config.Server{
+			"local": {
+				Default: true,
+				URL:     config.DefaultServerUrl,
+			},
+			"production": {
+				URL:       "https://spark-history.example.com",
+				VerifySSL: true,
+				Auth: &config.Auth{
+					Token: "your-token-here",
+				},
+				EMRClusterARN: "arn:aws:emr:us-east-1:123456789012:cluster/j-EXAMPLE",
+			},
+		},
+	}
+
+	comments := goyaml.CommentMap{
+		"$.servers.local":                      []*goyaml.Comment{goyaml.HeadComment(" minimal config for a local Spark History Server")},
+		"$.servers.local.default":              []*goyaml.Comment{goyaml.LineComment(" mark as default server")},
+		"$.servers.production":                 []*goyaml.Comment{goyaml.HeadComment(" remote server with auth and SSL")},
+		"$.servers.production.emr_cluster_arn": []*goyaml.Comment{goyaml.LineComment(" optional: for EMR-based clusters")},
+		"$.servers.production.auth":            []*goyaml.Comment{goyaml.HeadComment(" use token or username/password")},
+		"$.servers.production.auth.token":      []*goyaml.Comment{goyaml.LineComment(" bearer token")},
+	}
+
+	return goyaml.MarshalWithOptions(cfg, goyaml.WithComment(comments))
 }
 
 func newSetupSkillCmd() *cobra.Command {

--- a/skills/cli/cmd/setup_test.go
+++ b/skills/cli/cmd/setup_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/config"
+)
+
+func TestSampleConfig_RoundTrips(t *testing.T) {
+	out, err := sampleConfig()
+	if err != nil {
+		t.Fatalf("sampleConfig: %v", err)
+	}
+
+	p := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(p, out, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(p)
+	if err != nil {
+		t.Fatalf("Load round-trip failed: %v", err)
+	}
+
+	if cfg.Servers["local"].URL != config.DefaultServerUrl {
+		t.Errorf("local url = %q, want %q", cfg.Servers["local"].URL, config.DefaultServerUrl)
+	}
+	if !cfg.Servers["local"].Default {
+		t.Error("local.default should be true")
+	}
+	if cfg.Servers["production"].Auth == nil || cfg.Servers["production"].Auth.Token != "your-token-here" {
+		t.Error("production.auth.token not round-tripped")
+	}
+	if !cfg.Servers["production"].VerifySSL {
+		t.Error("production.verify_ssl should be true")
+	}
+}
+
+func TestSampleConfig_ContainsComments(t *testing.T) {
+	out, err := sampleConfig()
+	if err != nil {
+		t.Fatalf("sampleConfig: %v", err)
+	}
+
+	yaml := string(out)
+	for _, want := range []string{
+		"# minimal config for a local Spark History Server",
+		"# mark as default server",
+		"# remote server with auth and SSL",
+		"# optional: for EMR-based clusters",
+		"# use token or username/password",
+		"# bearer token",
+	} {
+		if !strings.Contains(yaml, want) {
+			t.Errorf("missing comment: %q", want)
+		}
+	}
+}

--- a/skills/cli/config/config.go
+++ b/skills/cli/config/config.go
@@ -1,28 +1,37 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env/v2"
 	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/providers/structs"
 	"github.com/knadh/koanf/v2"
+)
+
+const (
+	DefaultServerUrl = "http://localhost:18080"
+	EnvPREFIX        = "SHS_CLI__"
 )
 
 func Load(path string) (*Config, error) {
 	k := koanf.New(".")
 
-	if err := k.Load(file.Provider(path), yaml.Parser()); err != nil {
-		return nil, fmt.Errorf("reading config: %w", err)
+	err := k.Load(file.Provider(path), yaml.Parser())
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("could not load %s, %w", path, err)
 	}
 
 	// SHS_CLI__SERVERS__LOCAL__URL -> servers.local.url
 	// Double underscore (__) separates nesting levels.
 	if err := k.Load(env.Provider(".", env.Opt{
-		Prefix: "SHS_CLI__",
+		Prefix: EnvPREFIX,
 		TransformFunc: func(k, v string) (string, any) {
-			key := strings.ToLower(strings.TrimPrefix(k, "SHS_CLI__"))
+			key := strings.ToLower(strings.TrimPrefix(k, EnvPREFIX))
 			key = strings.ReplaceAll(key, "__", ".")
 			return key, v
 		},
@@ -34,23 +43,47 @@ func Load(path string) (*Config, error) {
 	if err := k.Unmarshal("", &cfg); err != nil {
 		return nil, fmt.Errorf("unmarshalling config: %w", err)
 	}
+
+	if len(k.MapKeys("servers")) == 0 {
+		if err := setDefault(k); err != nil {
+			return nil, err
+		}
+		return &cfg, k.Unmarshal("", &cfg)
+	}
 	return &cfg, nil
 }
 
+func setDefault(k *koanf.Koanf) error {
+	defaultValues := Config{
+		Servers: map[string]Server{
+			"local": {
+				Default:   true,
+				URL:       DefaultServerUrl,
+				VerifySSL: false,
+			},
+		},
+	}
+	err := k.Load(structs.Provider(defaultValues, "koanf"), nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 type Config struct {
-	Servers map[string]Server `koanf:"servers"`
+	Servers map[string]Server `koanf:"servers" yaml:"servers"`
 }
 
 type Server struct {
-	Default       bool   `koanf:"default"`
-	URL           string `koanf:"url"`
-	VerifySSL     *bool  `koanf:"verify_ssl"`
-	Auth          *Auth  `koanf:"auth"`
-	EMRClusterARN string `koanf:"emr_cluster_arn"`
+	Default       bool   `koanf:"default" yaml:"default"`
+	URL           string `koanf:"url" yaml:"url"`
+	VerifySSL     bool   `koanf:"verify_ssl" yaml:"verify_ssl"`
+	Auth          *Auth  `koanf:"auth" yaml:"auth,omitempty"`
+	EMRClusterARN string `koanf:"emr_cluster_arn" yaml:"emr_cluster_arn,omitempty"`
 }
 
 type Auth struct {
-	Username string `koanf:"username"`
-	Password string `koanf:"password"`
-	Token    string `koanf:"token"`
+	Username string `koanf:"username" yaml:"username,omitempty"`
+	Password string `koanf:"password" yaml:"password,omitempty"`
+	Token    string `koanf:"token" yaml:"token,omitempty"`
 }

--- a/skills/cli/config/config_test.go
+++ b/skills/cli/config/config_test.go
@@ -47,7 +47,7 @@ servers:
 	}
 
 	prod := cfg.Servers["prod"]
-	if prod.VerifySSL == nil || !*prod.VerifySSL {
+	if !prod.VerifySSL {
 		t.Error("expected prod.verify_ssl = true")
 	}
 	if prod.Auth == nil {
@@ -86,13 +86,6 @@ servers:
 	}
 }
 
-func TestLoad_MissingFile(t *testing.T) {
-	_, err := Load("/nonexistent/config.yaml")
-	if err == nil {
-		t.Fatal("expected error for missing file")
-	}
-}
-
 func TestLoad_InvalidYAML(t *testing.T) {
 	p := writeTestConfig(t, `{{{invalid`)
 	_, err := Load(p)
@@ -107,7 +100,7 @@ func TestLoad_EmptyServers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cfg.Servers) != 0 {
-		t.Errorf("expected 0 servers, got %d", len(cfg.Servers))
+	if len(cfg.Servers) != 1 {
+		t.Errorf("expected 1 servers, got %d", len(cfg.Servers))
 	}
 }

--- a/skills/cli/go.mod
+++ b/skills/cli/go.mod
@@ -16,11 +16,13 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/knadh/koanf/providers/structs v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/skills/cli/go.sum
+++ b/skills/cli/go.sum
@@ -6,6 +6,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
@@ -29,6 +31,8 @@ github.com/knadh/koanf/providers/env/v2 v2.0.0 h1:Ad5H3eun722u+FvchiIcEIJZsZ2M6o
 github.com/knadh/koanf/providers/env/v2 v2.0.0/go.mod h1:1g01PE+Ve1gBfWNNw2wmULRP0tc8RJrjn5p2N/jNCIc=
 github.com/knadh/koanf/providers/file v1.2.1 h1:bEWbtQwYrA+W2DtdBrQWyXqJaJSG3KrP3AESOJYp9wM=
 github.com/knadh/koanf/providers/file v1.2.1/go.mod h1:bp1PM5f83Q+TOUu10J/0ApLBd9uIzg+n9UgthfY+nRA=
+github.com/knadh/koanf/providers/structs v1.0.0 h1:DznjB7NQykhqCar2LvNug3MuxEQsZ5KvfgMbio+23u4=
+github.com/knadh/koanf/providers/structs v1.0.0/go.mod h1:kjo5TFtgpaZORlpoJqcbeLowM2cINodv8kX+oFAeQ1w=
 github.com/knadh/koanf/v2 v2.3.2 h1:Ee6tuzQYFwcZXQpc2MiVeC6qHMandf5SMUJJNoFp/c4=
 github.com/knadh/koanf/v2 v2.3.2/go.mod h1:gRb40VRAbd4iJMYYD5IxZ6hfuopFcXBpc9bbQpZwo28=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

The CLI no longer exits with an error when a configuration file does not exist. Instead, it defaults to `localhost:18080`. The error returned when attempting to connect to the local server should be sufficient for users to discover the need for configurations.

To help with configurations, we now have `setup config` command with an example / minimal config file output. This prints out a minimal yaml struct to stdout.  Users can redirect it to to a file and edit.
