### PR TITLE
CLI: add `logs` subcommand for executor/task log URLs

### DIFF
--- a/skills/cli/cmd/logs.go
+++ b/skills/cli/cmd/logs.go
@@ -51,25 +51,13 @@ one stage will match.`,
   shs logs -a APP --attempt 1 --task 145 --stage 12`,
 		PreRunE: requireAppID,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			hasExec := executorID != ""
-			hasTask := cmd.Flags().Changed("task")
-			if hasExec == hasTask {
-				return fmt.Errorf("exactly one of --executor or --task is required")
-			}
-			if !hasTask && cmd.Flags().Changed("stage") {
-				return fmt.Errorf("--stage is only valid with --task")
-			}
-			if !hasTask && cmd.Flags().Changed("stage-attempt") {
-				return fmt.Errorf("--stage-attempt is only valid with --task")
-			}
-
 			c, err := newClient()
 			if err != nil {
 				return err
 			}
 
 			var result *LogsResult
-			if hasExec {
+			if executorID != "" {
 				result, err = resolveByExecutor(cmd.Context(), c, executorID)
 			} else {
 				var stagePtr *int
@@ -129,6 +117,11 @@ one stage will match.`,
 	cmd.Flags().Int64VarP(&taskID, "task", "t", 0, "Task ID (mutually exclusive with --executor)")
 	cmd.Flags().IntVar(&stageID, "stage", 0, "Stage ID (optional; narrows --task search)")
 	cmd.Flags().IntVar(&stageAttemptID, "stage-attempt", 0, "Stage attempt ID (optional; defaults to latest attempt)")
+
+	cmd.MarkFlagsOneRequired("executor", "task")
+	cmd.MarkFlagsMutuallyExclusive("executor", "task")
+	cmd.MarkFlagsMutuallyExclusive("executor", "stage")
+	cmd.MarkFlagsMutuallyExclusive("executor", "stage-attempt")
 	return cmd
 }
 

--- a/skills/cli/cmd/logs.go
+++ b/skills/cli/cmd/logs.go
@@ -1,19 +1,286 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"text/tabwriter"
 
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/client"
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/util"
 	"github.com/spf13/cobra"
 )
 
-//nolint:unused
+// LogsResult is the emitted shape for `shs logs`.
+// Keys stdout / stderr / spark.log are Spark REST API conventions; surfaced as-is.
+type LogsResult struct {
+	ExecutorId     string            `json:"executorId"`
+	TaskId         *int64            `json:"taskId,omitempty"`
+	StageId        *int              `json:"stageId,omitempty"`
+	StageAttemptId *int              `json:"stageAttemptId,omitempty"`
+	Host           string            `json:"host,omitempty"`
+	Logs           map[string]string `json:"logs"`
+}
+
 func newLogsCmd() *cobra.Command {
-	return &cobra.Command{
+	var executorID string
+	var taskID int64
+	var stageID int
+	var stageAttemptID int
+
+	cmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Download logs for an application",
+		Short: "Get stdout/stderr/spark.log URLs for an executor or task",
+		Long: `Get stdout/stderr/spark.log URLs for an executor or a task.
+
+Exactly one of --executor or --task must be provided.
+
+When --task is set without --stage, all stages are scanned for the matching
+taskId. This can be slow on large applications; prefer passing --stage when
+known. A Spark taskId is globally unique across an application, so at most
+one stage will match.`,
+		Example: `  # By executor ID
+  shs logs -a APP --attempt 1 --executor 1
+
+  # By task ID (auto-scans stages)
+  shs logs -a APP --attempt 1 --task 145
+
+  # By task ID with known stage (fastest)
+  shs logs -a APP --attempt 1 --task 145 --stage 12`,
+		PreRunE: requireAppID,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("TODO: GET /applications/%s/logs\n", appID)
-			return nil
+			hasExec := executorID != ""
+			hasTask := cmd.Flags().Changed("task")
+			if hasExec == hasTask {
+				return fmt.Errorf("exactly one of --executor or --task is required")
+			}
+			if !hasTask && cmd.Flags().Changed("stage") {
+				return fmt.Errorf("--stage is only valid with --task")
+			}
+			if !hasTask && cmd.Flags().Changed("stage-attempt") {
+				return fmt.Errorf("--stage-attempt is only valid with --task")
+			}
+
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+
+			var result *LogsResult
+			if hasExec {
+				result, err = resolveByExecutor(cmd.Context(), c, executorID)
+			} else {
+				var stagePtr *int
+				if cmd.Flags().Changed("stage") {
+					stagePtr = &stageID
+				}
+				var saPtr *int
+				if cmd.Flags().Changed("stage-attempt") {
+					saPtr = &stageAttemptID
+				}
+				result, err = resolveByTask(cmd.Context(), c, taskID, stagePtr, saPtr)
+			}
+			if err != nil {
+				return err
+			}
+
+			return util.PrintOutput(cmd.OutOrStdout(), result, outputFmt, func(w io.Writer) error {
+				tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+				_, _ = fmt.Fprintf(tw, "EXECUTOR:\t%s\n", result.ExecutorId)
+				if result.TaskId != nil {
+					_, _ = fmt.Fprintf(tw, "TASK:\t%d\n", *result.TaskId)
+				}
+				if result.StageId != nil {
+					saStr := ""
+					if result.StageAttemptId != nil {
+						saStr = fmt.Sprintf("/%d", *result.StageAttemptId)
+					}
+					_, _ = fmt.Fprintf(tw, "STAGE:\t%d%s\n", *result.StageId, saStr)
+				}
+				if result.Host != "" {
+					_, _ = fmt.Fprintf(tw, "HOST:\t%s\n", result.Host)
+				}
+				preferred := []string{"spark.log", "stderr", "stdout"}
+				seen := map[string]bool{}
+				for _, k := range preferred {
+					if v, ok := result.Logs[k]; ok {
+						_, _ = fmt.Fprintf(tw, "%s:\t%s\n", k, v)
+						seen[k] = true
+					}
+				}
+				extra := make([]string, 0, len(result.Logs))
+				for k := range result.Logs {
+					if !seen[k] {
+						extra = append(extra, k)
+					}
+				}
+				sort.Strings(extra)
+				for _, k := range extra {
+					_, _ = fmt.Fprintf(tw, "%s:\t%s\n", k, result.Logs[k])
+				}
+				return tw.Flush()
+			})
 		},
 	}
+
+	cmd.Flags().StringVarP(&executorID, "executor", "e", "", "Executor ID (mutually exclusive with --task)")
+	cmd.Flags().Int64VarP(&taskID, "task", "t", 0, "Task ID (mutually exclusive with --executor)")
+	cmd.Flags().IntVar(&stageID, "stage", 0, "Stage ID (optional; narrows --task search)")
+	cmd.Flags().IntVar(&stageAttemptID, "stage-attempt", 0, "Stage attempt ID (optional; defaults to latest attempt)")
+	return cmd
+}
+
+func resolveByExecutor(ctx context.Context, c client.ClientWithResponsesInterface, id string) (*LogsResult, error) {
+	resp, err := c.ListAllExecutorsWithResponse(ctx, appID)
+	if err != nil {
+		return nil, err
+	}
+	body, err := util.CheckResponse(resp.JSON200, resp.HTTPResponse.Status)
+	if err != nil {
+		return nil, err
+	}
+	execs := util.Deref(body)
+	idx := slices.IndexFunc(execs, func(e client.Executor) bool {
+		return util.Deref(e.Id) == id
+	})
+	if idx == -1 {
+		return nil, fmt.Errorf("executor %q not found", id)
+	}
+	e := execs[idx]
+	logs := util.Deref(e.ExecutorLogs)
+	if len(logs) == 0 {
+		return nil, fmt.Errorf("executor %q has no log URLs (not yet assigned, or already cleaned up)", id)
+	}
+	return &LogsResult{
+		ExecutorId: util.Deref(e.Id),
+		Host:       util.Deref(e.HostPort),
+		Logs:       logs,
+	}, nil
+}
+
+func resolveByTask(ctx context.Context, c client.ClientWithResponsesInterface, taskID int64, stageID *int, stageAttemptID *int) (*LogsResult, error) {
+	if stageID != nil {
+		return findTaskInStage(ctx, c, taskID, *stageID, stageAttemptID)
+	}
+	// No stage hint: scan all stages. taskId is globally unique in a Spark app,
+	// so at most one stage will contain it.
+	stagesResp, err := c.ListStagesWithResponse(ctx, appID, &client.ListStagesParams{})
+	if err != nil {
+		return nil, err
+	}
+	stagesBody, err := util.CheckResponse(stagesResp.JSON200, stagesResp.HTTPResponse.Status)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[int]bool{}
+	for _, s := range util.Deref(stagesBody) {
+		sid := util.Deref(s.StageId)
+		if seen[sid] {
+			continue
+		}
+		seen[sid] = true
+		res, err := findTaskInStage(ctx, c, taskID, sid, nil)
+		if err == nil {
+			return res, nil
+		}
+		if !isTaskNotFound(err) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("task %d not found in any stage of application %s", taskID, appID)
+}
+
+// errTaskNotFound is a sentinel used internally when a given stage does not
+// contain the requested taskId; resolveByTask keeps iterating on this error.
+type errTaskNotFound struct{ taskID int64 }
+
+func (e errTaskNotFound) Error() string {
+	return fmt.Sprintf("task %d not found in stage", e.taskID)
+}
+
+func isTaskNotFound(err error) bool {
+	_, ok := err.(errTaskNotFound)
+	return ok
+}
+
+func findTaskInStage(ctx context.Context, c client.ClientWithResponsesInterface, taskID int64, stageID int, stageAttempt *int) (*LogsResult, error) {
+	attemptID, err := resolveStageAttempt(ctx, c, stageID, stageAttempt)
+	if err != nil {
+		return nil, err
+	}
+
+	const pageSize = 1000
+	offset := 0
+	for {
+		length := pageSize
+		params := &client.ListTasksParams{
+			Offset: &offset,
+			Length: &length,
+		}
+		resp, err := c.ListTasksWithResponse(ctx, appID, stageID, attemptID, params)
+		if err != nil {
+			return nil, err
+		}
+		body, err := util.CheckResponse(resp.JSON200, resp.HTTPResponse.Status)
+		if err != nil {
+			return nil, err
+		}
+		tasks := util.Deref(body)
+		if len(tasks) == 0 {
+			return nil, errTaskNotFound{taskID: taskID}
+		}
+		for i := range tasks {
+			t := &tasks[i]
+			if util.Deref(t.TaskId) == taskID {
+				logs := util.Deref(t.ExecutorLogs)
+				if len(logs) == 0 {
+					return nil, fmt.Errorf("task %d found in stage %d/%d but has no log URLs (running or cleaned up)", taskID, stageID, attemptID)
+				}
+				stageCopy := stageID
+				attemptCopy := attemptID
+				return &LogsResult{
+					ExecutorId:     util.Deref(t.ExecutorId),
+					TaskId:         t.TaskId,
+					StageId:        &stageCopy,
+					StageAttemptId: &attemptCopy,
+					Host:           util.Deref(t.Host),
+					Logs:           logs,
+				}, nil
+			}
+		}
+		if len(tasks) < pageSize {
+			return nil, errTaskNotFound{taskID: taskID}
+		}
+		offset += pageSize
+	}
+}
+
+func resolveStageAttempt(ctx context.Context, c client.ClientWithResponsesInterface, stageID int, explicit *int) (int, error) {
+	if explicit != nil {
+		return *explicit, nil
+	}
+	resp, err := c.ListStageAttemptsWithResponse(ctx, appID, stageID, &client.ListStageAttemptsParams{})
+	if err != nil {
+		return 0, err
+	}
+	if resp.HTTPResponse.StatusCode == 404 {
+		return 0, fmt.Errorf("stage %d not found", stageID)
+	}
+	body, err := util.CheckResponse(resp.JSON200, resp.HTTPResponse.Status)
+	if err != nil {
+		return 0, err
+	}
+	attempts := util.Deref(body)
+	if len(attempts) == 0 {
+		return 0, fmt.Errorf("no attempts found for stage %d", stageID)
+	}
+	latest := 0
+	for _, a := range attempts {
+		if id := util.Deref(a.AttemptId); id > latest {
+			latest = id
+		}
+	}
+	return latest, nil
 }

--- a/skills/cli/cmd/logs_test.go
+++ b/skills/cli/cmd/logs_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestIsTaskNotFound(t *testing.T) {
+	if !isTaskNotFound(errTaskNotFound{taskID: 42}) {
+		t.Fatalf("expected errTaskNotFound to be recognized")
+	}
+	if isTaskNotFound(errors.New("some other error")) {
+		t.Fatalf("plain error should not be recognized as task-not-found")
+	}
+	if isTaskNotFound(nil) {
+		t.Fatalf("nil should not be recognized as task-not-found")
+	}
+}
+
+func TestErrTaskNotFoundMessage(t *testing.T) {
+	err := errTaskNotFound{taskID: 145}
+	if !strings.Contains(err.Error(), "145") {
+		t.Fatalf("error message must include taskID, got %q", err.Error())
+	}
+}
+
+func TestLogsResultJSONShape(t *testing.T) {
+	taskID := int64(145)
+	stageID := 12
+	stageAttempt := 0
+	r := &LogsResult{
+		ExecutorId:     "1",
+		TaskId:         &taskID,
+		StageId:        &stageID,
+		StageAttemptId: &stageAttempt,
+		Host:           "host.example.com:12345",
+		Logs: map[string]string{
+			"stdout":    "http://host/stdout",
+			"stderr":    "http://host/stderr",
+			"spark.log": "http://host/spark.log",
+		},
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, want := range []string{
+		`"executorId":"1"`,
+		`"taskId":145`,
+		`"stageId":12`,
+		`"stageAttemptId":0`,
+		`"host":"host.example.com:12345"`,
+		`"stdout":"http://host/stdout"`,
+		`"stderr":"http://host/stderr"`,
+		`"spark.log":"http://host/spark.log"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("want substring %s in %s", want, got)
+		}
+	}
+}
+
+// TestLogsResultJSONOmitsEmpty verifies that pointer fields collapse when unset.
+func TestLogsResultJSONOmitsEmpty(t *testing.T) {
+	r := &LogsResult{
+		ExecutorId: "driver",
+		Logs: map[string]string{
+			"spark.log": "http://x/spark.log",
+		},
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, forbidden := range []string{`"taskId"`, `"stageId"`, `"stageAttemptId"`, `"host"`} {
+		if strings.Contains(got, forbidden) {
+			t.Errorf("should omit %s when empty/nil; got %s", forbidden, got)
+		}
+	}
+}
+
+// TestLogsCommandFlagValidation exercises the RunE guard rails without an HTTP
+// call. These paths fail before reaching newClient(), so no mock is needed.
+func TestLogsCommandFlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   []string
+		wantErr string
+	}{
+		{
+			name:    "no executor no task",
+			flags:   []string{},
+			wantErr: "exactly one of --executor or --task is required",
+		},
+		{
+			name:    "both executor and task",
+			flags:   []string{"--executor", "1", "--task", "5"},
+			wantErr: "exactly one of --executor or --task is required",
+		},
+		{
+			name:    "stage without task",
+			flags:   []string{"--executor", "1", "--stage", "2"},
+			wantErr: "--stage is only valid with --task",
+		},
+		{
+			name:    "stage-attempt without task",
+			flags:   []string{"--executor", "1", "--stage-attempt", "0"},
+			wantErr: "--stage-attempt is only valid with --task",
+		},
+	}
+
+	origAppID := appID
+	defer func() { appID = origAppID }()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appID = "application_test_00001"
+
+			cmd := newLogsCmd()
+			// silence any incidental stdout.
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(tt.flags)
+			// parse flags explicitly so Changed() works, then invoke RunE.
+			if err := cmd.ParseFlags(tt.flags); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.RunE(cmd, []string{})
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("want error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+// TestNewLogsCmdDeclaresExpectedFlags guards the public flag surface.
+func TestNewLogsCmdDeclaresExpectedFlags(t *testing.T) {
+	cmd := newLogsCmd()
+	for _, name := range []string{"executor", "task", "stage", "stage-attempt"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("flag %q missing", name)
+		}
+	}
+	// Verify short aliases.
+	for alias, long := range map[string]string{"e": "executor", "t": "task"} {
+		if f := cmd.Flags().ShorthandLookup(alias); f == nil || f.Name != long {
+			t.Errorf("short -%s should alias --%s", alias, long)
+		}
+	}
+}
+
+// TestPreferredLogKeyOrder guards the ordering contract used by the text-mode output.
+// spark.log / stderr / stdout first (in that order), then extras alphabetical.
+func TestPreferredLogKeyOrder(t *testing.T) {
+	preferred := []string{"spark.log", "stderr", "stdout"}
+	have := map[string]string{
+		"stdout":    "u1",
+		"spark.log": "u2",
+		"stderr":    "u3",
+		"extra-log": "u4",
+	}
+	seen := map[string]bool{}
+	order := []string{}
+	for _, k := range preferred {
+		if _, ok := have[k]; ok {
+			order = append(order, k)
+			seen[k] = true
+		}
+	}
+	extras := []string{}
+	for k := range have {
+		if !seen[k] {
+			extras = append(extras, k)
+		}
+	}
+	sort.Strings(extras)
+	order = append(order, extras...)
+
+	want := []string{"spark.log", "stderr", "stdout", "extra-log"}
+	if len(order) != len(want) {
+		t.Fatalf("len mismatch: got %v want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Errorf("pos %d: got %s want %s", i, order[i], want[i])
+		}
+	}
+}
+
+// Ensure the cobra import stays used when we add future integration tests.
+var _ = (*cobra.Command)(nil)

--- a/skills/cli/cmd/logs_test.go
+++ b/skills/cli/cmd/logs_test.go
@@ -87,33 +87,36 @@ func TestLogsResultJSONOmitsEmpty(t *testing.T) {
 	}
 }
 
-// TestLogsCommandFlagValidation exercises the RunE guard rails without an HTTP
-// call. These paths fail before reaching newClient(), so no mock is needed.
+// TestLogsCommandFlagValidation exercises the cobra flag-group guards
+// (MarkFlagsOneRequired / MarkFlagsMutuallyExclusive) declared on the logs
+// command. Validation fires before PreRunE/RunE, so no HTTP mock is needed.
+// Assertions match keywords inside cobra's built-in group error messages
+// rather than exact strings so a cobra-version bump does not break tests.
 func TestLogsCommandFlagValidation(t *testing.T) {
 	tests := []struct {
-		name    string
-		flags   []string
-		wantErr string
+		name        string
+		flags       []string
+		wantKeyword []string
 	}{
 		{
-			name:    "no executor no task",
-			flags:   []string{},
-			wantErr: "exactly one of --executor or --task is required",
+			name:        "no executor no task",
+			flags:       []string{},
+			wantKeyword: []string{"at least one of", "executor", "task"},
 		},
 		{
-			name:    "both executor and task",
-			flags:   []string{"--executor", "1", "--task", "5"},
-			wantErr: "exactly one of --executor or --task is required",
+			name:        "both executor and task",
+			flags:       []string{"--executor", "1", "--task", "5"},
+			wantKeyword: []string{"none of the others can be", "executor", "task"},
 		},
 		{
-			name:    "stage without task",
-			flags:   []string{"--executor", "1", "--stage", "2"},
-			wantErr: "--stage is only valid with --task",
+			name:        "stage with executor",
+			flags:       []string{"--executor", "1", "--stage", "2"},
+			wantKeyword: []string{"none of the others can be", "executor", "stage"},
 		},
 		{
-			name:    "stage-attempt without task",
-			flags:   []string{"--executor", "1", "--stage-attempt", "0"},
-			wantErr: "--stage-attempt is only valid with --task",
+			name:        "stage-attempt with executor",
+			flags:       []string{"--executor", "1", "--stage-attempt", "0"},
+			wantKeyword: []string{"none of the others can be", "executor", "stage-attempt"},
 		},
 	}
 
@@ -125,21 +128,22 @@ func TestLogsCommandFlagValidation(t *testing.T) {
 			appID = "application_test_00001"
 
 			cmd := newLogsCmd()
-			// silence any incidental stdout.
 			var buf bytes.Buffer
 			cmd.SetOut(&buf)
 			cmd.SetErr(&buf)
+			// SilenceUsage/Errors prevent cobra from printing usage to the
+			// test buffer when group validation fails.
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 			cmd.SetArgs(tt.flags)
-			// parse flags explicitly so Changed() works, then invoke RunE.
-			if err := cmd.ParseFlags(tt.flags); err != nil {
-				t.Fatalf("parse flags: %v", err)
-			}
-			err := cmd.RunE(cmd, []string{})
+			err := cmd.Execute()
 			if err == nil {
-				t.Fatalf("expected error %q, got nil", tt.wantErr)
+				t.Fatalf("expected error with keywords %v, got nil", tt.wantKeyword)
 			}
-			if !strings.Contains(err.Error(), tt.wantErr) {
-				t.Fatalf("want error containing %q, got %q", tt.wantErr, err.Error())
+			for _, kw := range tt.wantKeyword {
+				if !strings.Contains(err.Error(), kw) {
+					t.Fatalf("want error containing %q, got %q", kw, err.Error())
+				}
 			}
 		})
 	}

--- a/skills/cli/cmd/root.go
+++ b/skills/cli/cmd/root.go
@@ -44,7 +44,7 @@ func init() {
 		newSQLCmd(),
 		newEnvironmentCmd(),
 		//newStorageCmd(),
-		//newLogsCmd(),
+		newLogsCmd(),
 		newPrimeCmd(),
 		newCompareCmd(),
 		newServersCmd(),


### PR DESCRIPTION
  # 🔄 Pull Request

  ## 📝 Description
  Adds a `shs logs` subcommand that returns the **stdout / stderr / spark.log URLs** for a specific executor or task in one call.

  Current CLI already surfaces `executorLogs` inside `shs executors -o json`, but users needed to grep or `jq` through the payload to extract the three URLs for a given executor, and there was no path at all for "give me the logs for task N". The `logs` subcommand makes both direct, with a stable output schema.

  The Spark REST API already populates `executorLogs` on both `Executor` and `Task` objects, so this is a client-side convenience: no new endpoints, no new payloads.

  A `cmd/logs.go` stub had been committed but was commented out in `cmd/root.go`; this PR replaces the stub with a full implementation and registers it.