### PR TITLE
fix(cli): Remove stale config reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ kubectl port-forward svc/mcp-apache-spark-history-server 18888:18888
 
 - **[AWS Glue](examples/aws/glue/README.md)** — Connect to Glue Spark History Server
 - **[Amazon EMR](examples/aws/emr/README.md)** — Use EMR Persistent UI for Spark analysis
-- **AWS Spark Troubleshooting** — One-shot root cause analysis and code fix recommendations for failed Spark workloads (EMR EC2, EMR Serverless). Automatically available when AWS credentials and `AWS_REGION` are configured. Set `AWS_PROFILE` if using a named profile.
+- **AWS Spark Troubleshooting** — One-shot root cause analysis and code fix recommendations for failed Spark workloads (EMR EC2, EMR Serverless). Automatically available when AWS credentials and region are configured. See [IAM setup guide](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-troubleshooting-agent-iam-setup.html) for required permissions.
 
 ---
 

--- a/skills/cli/README.md
+++ b/skills/cli/README.md
@@ -411,14 +411,17 @@ One-shot root cause analysis and code fix recommendations for failed Spark workl
 
 ### Configuration
 
-Add to your `config.yaml`:
+No config file changes needed. AWS credentials and region are resolved via the [default credential chain](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-sdk.html#credentials) (environment variables, shared credentials file, IAM roles, etc.).
 
-```yaml
-aws_troubleshooting:
-  region: us-east-1
+```bash
+# Example: set via environment variables
+export AWS_REGION=us-east-1          # or configure in ~/.aws/config
+export AWS_PROFILE=my-profile        # optional
 ```
 
-AWS credentials are resolved via the [default credential chain](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-sdk.html#credentials) (environment variables, shared credentials, IAM roles). Set `AWS_PROFILE` if you need a specific profile.
+### IAM Permissions
+
+Your IAM role needs permissions to access the SageMaker Unified Studio MCP endpoint and the relevant EMR/Serverless APIs. See the [IAM setup guide](https://docs.aws.amazon.com/emr/latest/ReleaseGuide/spark-troubleshooting-agent-iam-setup.html) for required policies.
 
 ### Usage
 

--- a/skills/cli/cmd/prime.go
+++ b/skills/cli/cmd/prime.go
@@ -35,7 +35,7 @@ COMMANDS
     --server-a NAME  Server for app A (overrides --server)
     --server-b NAME  Server for app B (overrides --server)
   shs servers                     List configured servers
-  shs troubleshoot -a STEP_ID --cluster CLUSTER_ID          Analyze failed EMR EC2 step (requires aws_troubleshooting config)
+  shs troubleshoot -a STEP_ID --cluster CLUSTER_ID          Analyze failed EMR EC2 step (requires AWS credentials + region)
   shs troubleshoot -a APP_ID --emr-serverless-app ID --job-run ID  Analyze failed EMR Serverless job run
   shs setup config                Print a sample config.yaml to get started
   shs version                     CLI + server Spark version
@@ -160,7 +160,7 @@ COMMON WORKFLOWS
   Get Spark config for an app:
     shs env -a APP_ID --section spark
 
-  Troubleshoot a failed EMR step (requires aws_troubleshooting config + AWS credentials):
+  Troubleshoot a failed EMR step (requires AWS credentials + region):
     shs troubleshoot -a STEP_ID --cluster j-XXXXX
     # Returns root cause analysis and auto-chains to code recommendation if applicable
 


### PR DESCRIPTION
Docs fix — update troubleshooting references to reflect the zero-config approach (merged in #175 and #176).

**Changes:**
- `README.md` — Replace `AWS_REGION` mention with IAM setup guide link
- `skills/cli/README.md` — Replace config.yaml section with env var docs + IAM setup guide link
- `skills/cli/cmd/prime.go` — Update troubleshoot descriptions to "requires AWS credentials + region"