### PR TITLE
fix: handle missing memory_metrics in executor summary

### DIFF
--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -595,14 +595,19 @@ def compare_job_environments(
 
 def _calculate_executor_metrics(executors):
     """Calculate executor summary metrics from executor list."""
+
+    def memory_used(executor):
+        metrics = executor.memory_metrics
+        if metrics is None:
+            return 0
+        return (metrics.used_on_heap_storage_memory or 0) + (
+            metrics.used_off_heap_storage_memory or 0
+        )
+
     return {
         "total_executors": len(executors),
         "active_executors": sum(1 for e in executors if e.is_active),
-        "memory_used": sum(
-            e.memory_metrics.used_on_heap_storage_memory
-            + e.memory_metrics.used_off_heap_storage_memory
-            for e in executors
-        ),
+        "memory_used": sum(memory_used(e) for e in executors),
         "disk_used": sum(e.disk_used for e in executors),
         "completed_tasks": sum(e.completed_tasks for e in executors),
         "failed_tasks": sum(e.failed_tasks for e in executors),

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -12,6 +12,7 @@ from spark_history_mcp.models.spark_types import (
     TaskMetricDistributions,
 )
 from spark_history_mcp.tools.tools import (
+    _calculate_executor_metrics,
     get_application,
     get_client_or_default,
     get_sql_execution,
@@ -394,6 +395,51 @@ class TestTools(unittest.TestCase):
             get_application("non-existent-app")
 
         self.assertIn("Application not found", str(context.exception))
+
+    def test_calculate_executor_metrics_handles_missing_memory_metrics(self):
+        """Test executor summary handles executors without memoryMetrics.
+
+        ExecutorSummary.memory_metrics and the inner used_*_storage_memory
+        fields are declared Optional in models.spark_types, and Spark History
+        Server may return executors (e.g. the driver entry, or executors from
+        replayed event logs missing executor metrics events) without these
+        fields populated. The summary aggregation must not crash in that case.
+        """
+        executor_without_memory = MagicMock()
+        executor_without_memory.is_active = True
+        executor_without_memory.memory_metrics = None
+        executor_without_memory.disk_used = 10
+        executor_without_memory.completed_tasks = 2
+        executor_without_memory.failed_tasks = 1
+        executor_without_memory.total_duration = 100
+        executor_without_memory.total_gc_time = 5
+        executor_without_memory.total_input_bytes = 20
+        executor_without_memory.total_shuffle_read = 30
+        executor_without_memory.total_shuffle_write = 40
+
+        memory_metrics = MagicMock()
+        memory_metrics.used_on_heap_storage_memory = 7
+        memory_metrics.used_off_heap_storage_memory = None
+        executor_with_partial_memory = MagicMock()
+        executor_with_partial_memory.is_active = False
+        executor_with_partial_memory.memory_metrics = memory_metrics
+        executor_with_partial_memory.disk_used = 1
+        executor_with_partial_memory.completed_tasks = 3
+        executor_with_partial_memory.failed_tasks = 0
+        executor_with_partial_memory.total_duration = 200
+        executor_with_partial_memory.total_gc_time = 6
+        executor_with_partial_memory.total_input_bytes = 21
+        executor_with_partial_memory.total_shuffle_read = 31
+        executor_with_partial_memory.total_shuffle_write = 41
+
+        result = _calculate_executor_metrics(
+            [executor_without_memory, executor_with_partial_memory]
+        )
+
+        self.assertEqual(result["total_executors"], 2)
+        self.assertEqual(result["active_executors"], 1)
+        self.assertEqual(result["memory_used"], 7)
+        self.assertEqual(result["disk_used"], 11)
 
     # Tests for list_applications tool
     @patch("spark_history_mcp.tools.tools.mcp.get_context")


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

`_calculate_executor_metrics` in `tools/tools.py` crashes when an `ExecutorSummary` has `memory_metrics = None`, or when either `used_on_heap_storage_memory` / `used_off_heap_storage_memory` is `None`:

```python
"memory_used": sum(
    e.memory_metrics.used_on_heap_storage_memory
    + e.memory_metrics.used_off_heap_storage_memory
    for e in executors
),
```

This is inconsistent with our own model — in [`models/spark_types.py`](../blob/main/src/spark_history_mcp/models/spark_types.py) these are all declared `Optional`:

```python
class ExecutorSummary(BaseModel):
    ...
    memory_metrics: Optional["MemoryMetrics"] = Field(None, alias="memoryMetrics")

class MemoryMetrics(BaseModel):
    used_on_heap_storage_memory: Optional[int] = Field(...)
    used_off_heap_storage_memory: Optional[int] = Field(...)
```

In practice Spark History Server can return executors without populated `memoryMetrics` — e.g. the driver entry, or executors from replayed event logs where `ExecutorMetricsUpdate` events are missing. When that happens, `get_executor_summary` (and downstream tools like `compare_job_performance` that call `_calc_executor_summary_from_client`) raise `AttributeError: 'NoneType' object has no attribute 'used_on_heap_storage_memory'` or `TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'`.

This is the same defensive-defaults pattern as #159 (Spark 3.x `ThreadStackTrace`) — the model already says these may be `None`, the consumer just needs to honor it.

### Fix

Extract a small `memory_used(executor)` helper that returns `0` when `memory_metrics` is `None`, and treats either sub-field being `None` as `0`. No behavior change for the happy path.

## 🎯 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring

## 🧪 Testing

- [x] ✅ All existing tests pass (`uv run pytest tests/unit/` — 74 tests passed)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [x] 🚀 Tested against a real Spark History Server (production deployment, where this bug surfaced)

### 🔬 Test Commands Run

```bash
uv run pytest tests/unit/ -v
uv run ruff check src/spark_history_mcp/tools/tools.py tests/unit/test_tools.py
uv run ruff format --check src/spark_history_mcp/tools/tools.py tests/unit/test_tools.py
```

### New Test Case

`test_calculate_executor_metrics_handles_missing_memory_metrics` — covers two cases in one call:
1. An executor whose `memory_metrics` object is `None` entirely.
2. An executor whose `memory_metrics` is present but `used_off_heap_storage_memory` is `None`.

Asserts the aggregated `memory_used` equals only the non-null contribution (`7`), and other aggregations (`disk_used`, counts) are unaffected.

## 🛠️ New Tools Added

N/A — bug fix in existing helper.

## ✅ Checklist

- [x] 🔍 Code follows project style guidelines
- [x] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation — N/A (internal helper, behavior is now consistent with documented Optional types)
- [x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md — N/A

## 📚 Related Issues

Same shape as the defensive-defaults fix in #159.

## 🤔 Additional Context

### Files Changed

- `src/spark_history_mcp/tools/tools.py` — null-safe `memory_used` helper in `_calculate_executor_metrics`
- `tests/unit/test_tools.py` — new unit test covering both `None` scenarios