### PR TITLE
fix(cli): Use platform-prefixed flags for troubleshoot command

### DIFF
--- a/skills/cli/cmd/prime.go
+++ b/skills/cli/cmd/prime.go
@@ -35,8 +35,8 @@ COMMANDS
     --server-a NAME  Server for app A (overrides --server)
     --server-b NAME  Server for app B (overrides --server)
   shs servers                     List configured servers
-  shs troubleshoot -a STEP_ID --cluster CLUSTER_ID          Analyze failed EMR EC2 step (requires AWS credentials + region)
-  shs troubleshoot -a APP_ID --emr-serverless-app ID --job-run ID  Analyze failed EMR Serverless job run
+  shs troubleshoot --emr-ec2-cluster CLUSTER_ID --emr-ec2-step STEP_ID  Analyze failed EMR EC2 step (requires AWS credentials + region)
+  shs troubleshoot --emr-serverless-app ID --emr-serverless-run ID     Analyze failed EMR Serverless job run
   shs setup config                Print a sample config.yaml to get started
   shs version                     CLI + server Spark version
 
@@ -161,7 +161,7 @@ COMMON WORKFLOWS
     shs env -a APP_ID --section spark
 
   Troubleshoot a failed EMR step (requires AWS credentials + region):
-    shs troubleshoot -a STEP_ID --cluster j-XXXXX
+    shs troubleshoot --emr-ec2-cluster j-XXXXX --emr-ec2-step s-XXXXX
     # Returns root cause analysis and auto-chains to code recommendation if applicable
 
 DATA MODEL

--- a/skills/cli/cmd/troubleshoot.go
+++ b/skills/cli/cmd/troubleshoot.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	clusterID        string
+	emrEC2Cluster    string
+	emrEC2Step       string
 	emrServerlessApp string
 	emrServerlessRun string
 )
@@ -20,8 +21,7 @@ func newTroubleshootCmd() *cobra.Command {
 Supports EMR on EC2 and EMR Serverless platforms.
 
 Requires valid AWS credentials (via environment variables, shared credentials, or IAM roles)
-and AWS_REGION to be set.`,
-		PreRunE: requireAppID,
+and a configured AWS region.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			platformType, platformParams, err := resolvePlatform()
 			if err != nil {
@@ -32,29 +32,30 @@ and AWS_REGION to be set.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&clusterID, "cluster", "", "EMR cluster ID (e.g., j-XXXXX)")
+	cmd.Flags().StringVar(&emrEC2Cluster, "emr-ec2-cluster", "", "EMR EC2 cluster ID (e.g., j-XXXXX)")
+	cmd.Flags().StringVar(&emrEC2Step, "emr-ec2-step", "", "EMR EC2 step ID (e.g., s-XXXXX)")
 	cmd.Flags().StringVar(&emrServerlessApp, "emr-serverless-app", "", "EMR Serverless application ID")
-	cmd.Flags().StringVar(&emrServerlessRun, "job-run", "", "EMR Serverless job run ID")
-	cmd.MarkFlagsMutuallyExclusive("cluster", "emr-serverless-app")
-	cmd.MarkFlagsOneRequired("cluster", "emr-serverless-app")
+	cmd.Flags().StringVar(&emrServerlessRun, "emr-serverless-run", "", "EMR Serverless job run ID")
+	cmd.MarkFlagsMutuallyExclusive("emr-ec2-cluster", "emr-serverless-app")
+	cmd.MarkFlagsOneRequired("emr-ec2-cluster", "emr-serverless-app")
 
 	return cmd
 }
 
 func resolvePlatform() (string, map[string]string, error) {
 	switch {
-	case clusterID != "":
-		if appID == "" {
-			return "", nil, fmt.Errorf("--app-id is required for EMR EC2 troubleshooting")
+	case emrEC2Cluster != "":
+		if emrEC2Step == "" {
+			return "", nil, fmt.Errorf("--emr-ec2-step is required with --emr-ec2-cluster")
 		}
 		return "EMR_EC2", map[string]string{
-			"cluster_id": clusterID,
-			"step_id":    appID,
+			"cluster_id": emrEC2Cluster,
+			"step_id":    emrEC2Step,
 		}, nil
 
 	case emrServerlessApp != "":
 		if emrServerlessRun == "" {
-			return "", nil, fmt.Errorf("--job-run is required with --emr-serverless-app")
+			return "", nil, fmt.Errorf("--emr-serverless-run is required with --emr-serverless-app")
 		}
 		return "EMR_SERVERLESS", map[string]string{
 			"application_id": emrServerlessApp,
@@ -62,6 +63,6 @@ func resolvePlatform() (string, map[string]string, error) {
 		}, nil
 
 	default:
-		return "", nil, fmt.Errorf("specify --cluster or --emr-serverless-app")
+		return "", nil, fmt.Errorf("specify --emr-ec2-cluster or --emr-serverless-app")
 	}
 }

--- a/skills/cli/cmd/troubleshoot_test.go
+++ b/skills/cli/cmd/troubleshoot_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestResolvePlatform_EMR_EC2(t *testing.T) {
-	appID = "s-XXXXX"
-	clusterID = "j-12345"
+	emrEC2Cluster = "j-12345"
+	emrEC2Step = "s-XXXXX"
 	emrServerlessApp = ""
 
 	pType, params, err := resolvePlatform()
@@ -24,9 +24,19 @@ func TestResolvePlatform_EMR_EC2(t *testing.T) {
 	}
 }
 
+func TestResolvePlatform_EMR_EC2_MissingStep(t *testing.T) {
+	emrEC2Cluster = "j-12345"
+	emrEC2Step = ""
+	emrServerlessApp = ""
+
+	_, _, err := resolvePlatform()
+	if err == nil {
+		t.Fatal("expected error when --emr-ec2-step missing")
+	}
+}
+
 func TestResolvePlatform_EMRServerless(t *testing.T) {
-	appID = ""
-	clusterID = ""
+	emrEC2Cluster = ""
 	emrServerlessApp = "00abc"
 	emrServerlessRun = "00xyz"
 
@@ -43,13 +53,13 @@ func TestResolvePlatform_EMRServerless(t *testing.T) {
 	}
 }
 
-func TestResolvePlatform_EMRServerlessMissingRunID(t *testing.T) {
-	clusterID = ""
+func TestResolvePlatform_EMRServerlessMissingRun(t *testing.T) {
+	emrEC2Cluster = ""
 	emrServerlessApp = "00abc"
 	emrServerlessRun = ""
 
 	_, _, err := resolvePlatform()
 	if err == nil {
-		t.Fatal("expected error when --job-run missing")
+		t.Fatal("expected error when --emr-serverless-run missing")
 	}
 }


### PR DESCRIPTION
Replace generic flags with platform-scoped names to avoid ambiguity as more platforms are added (Glue, EMR on EKS).

**Before:**
```bash
shs troubleshoot -a s-XXXXX --cluster j-XXXXX          # -a misused as step_id
shs troubleshoot -a unused --emr-serverless-app ID --job-run ID  # -a required but ignored
```

**After:**
```bash
shs troubleshoot --emr-ec2-cluster j-XXXXX --emr-ec2-step s-XXXXX
shs troubleshoot --emr-serverless-app ID --emr-serverless-run ID
```

### Test Results

**EMR EC2** (disk space failure):
```
$ shs troubleshoot --emr-ec2-cluster j-1WAYPDV330QFC --emr-ec2-step s-038715833EFK6BSFE2KC

Analyzing Spark workload...
Analysis Result:
  analysis_status: SUCCEEDED
  analysis_category: DISK_NO_SPACE_ERROR
  root_cause: Disk space exhaustion on worker nodes — shuffle data with 500 partitions
              exceeded local disk capacity, YARN marked nodes unhealthy at 90% threshold
  recommendation: Larger EBS volumes, reduce shuffle partitions, add dedicated EBS for YARN local dirs
```

**EMR Serverless** (schema mismatch):
```
$ shs troubleshoot --emr-serverless-app 00g54arjc4lgf009 --emr-serverless-run 00g5mamp5ivfto0b

Analyzing Spark workload...
Analysis Result:
  analysis_status: SUCCEEDED
  analysis_category: QUERY_ERROR
  root_cause: UNION operation with mismatched column counts (22 vs 21) —
              radio_catalog_1 has alexa_slogan column missing from radio_catalog_2
  recommendation: Add missing column to radio_catalog_2 or remove from radio_catalog_1
```

**Error cases:**
```
$ shs troubleshoot --emr-ec2-cluster j-XXXXX
Error: --emr-ec2-step is required with --emr-ec2-cluster

$ shs troubleshoot --emr-serverless-app 00abc
Error: --emr-serverless-run is required with --emr-serverless-app
```

### Changes
- Remove `PreRunE: requireAppID` — troubleshoot no longer depends on `-a`
- Add `--emr-ec2-cluster` and `--emr-ec2-step` flags (replaces `-a` + `--cluster`)
- Rename `--job-run` to `--emr-serverless-run` (avoids collision with future Glue `--glue-run`)
- Update `shs prime` output
- Update tests
