### PR TITLE
feat(cli): add threaddump subcommand

### DIFF
--- a/skills/cli/README.md
+++ b/skills/cli/README.md
@@ -124,6 +124,8 @@ COMMANDS
   shs stages -a APP_ID STAGE --errors  Show failed tasks with errors
   shs executors -a APP_ID         List active executors
   shs executors -a APP_ID EXEC    Get executor detail
+  shs threaddump -a APP_ID driver         JVM thread dump for the driver (running app only)
+  shs threaddump -a APP_ID EXEC           JVM thread dump for an executor
   shs logs -a APP_ID --executor EXEC          Get stdout/stderr/spark.log URLs for executor
   shs logs -a APP_ID --task TASK              Get log URLs for task (auto-scans stages)
   shs logs -a APP_ID --task TASK --stage S    Faster: known stage
@@ -163,6 +165,10 @@ COMMAND DETAILS
   stages     --status active|complete|pending|failed  --sort failed-tasks|duration|id  --errors
   executors  --all (include dead)  --summary (peak memory/OOM view)  --timeline (resource usage over time)
              --sort failed-tasks|duration|gc|id
+  threaddump --state STATE (RUNNABLE|BLOCKED|WAITING|TIMED_WAITING|...)
+             --name SUBSTR (case-insensitive name match)  --blocked-only (only locked/blocked threads)
+             Endpoint requires the application to be running (live driver UI). Default output is a
+             thread summary table; use -o json|yaml for full stack traces.
   logs       --executor EXEC | --task TASK (mutually exclusive)
              --stage STAGE (optional, narrows --task search)  --stage-attempt N (optional)
   sql        --status completed|running|failed  --sort duration|id  --plan  --summary  --initial-plan
@@ -204,6 +210,13 @@ COMMON WORKFLOWS
     shs executors -a APP_ID --summary   # peak memory, OOM status, dead first
     shs executors -a APP_ID --timeline  # resource usage over time
     shs executors -a APP_ID EXECUTOR_ID
+
+  Inspect a hung driver or executor (running apps only):
+    shs threaddump -a APP_ID driver                       # all driver threads
+    shs threaddump -a APP_ID driver --state BLOCKED       # filter by JVM state
+    shs threaddump -a APP_ID driver --name dispatcher     # name substring
+    shs threaddump -a APP_ID driver --blocked-only        # threads with a lock or blocking owner
+    shs threaddump -a APP_ID 1 -o json > exec1.json       # full stack traces for executor 1
 
   Get log URLs (stdout/stderr/spark.log):
     shs logs -a APP_ID --executor EXECUTOR_ID         # all logs for an executor
@@ -308,6 +321,8 @@ Env vars merge on top of the config file, so you can keep a base config and over
 | `shs stages -a APP STAGE --errors` | Failed tasks with error messages |
 | `shs executors -a APP` | List executors |
 | `shs executors -a APP --summary` | Peak memory and OOM status |
+| `shs threaddump -a APP driver` | JVM thread dump for the driver (running apps only) |
+| `shs threaddump -a APP EXEC` | JVM thread dump for an executor |
 | `shs sql -a APP` | List SQL executions |
 | `shs sql -a APP EXEC_ID` | SQL execution header |
 | `shs sql -a APP EXEC_ID --plan` | Query plan and node metrics |

--- a/skills/cli/cmd/root.go
+++ b/skills/cli/cmd/root.go
@@ -41,6 +41,7 @@ func init() {
 		newJobsCmd(),
 		newStagesCmd(),
 		newExecutorsCmd(),
+		newThreaddumpCmd(),
 		newSQLCmd(),
 		newEnvironmentCmd(),
 		//newStorageCmd(),

--- a/skills/cli/cmd/threaddump.go
+++ b/skills/cli/cmd/threaddump.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/client"
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/util"
+	"github.com/spf13/cobra"
+)
+
+type threadRow struct {
+	ID        int64  `col:"ID"`
+	Name      string `col:"NAME"`
+	State     string `col:"STATE"`
+	Daemon    bool   `col:"DAEMON"`
+	BlockedBy int64  `col:"BLOCKED_BY"`
+	Lock      string `col:"LOCK"`
+}
+
+func newThreaddumpCmd() *cobra.Command {
+	var stateFilter string
+	var nameFilter string
+	var blockedOnly bool
+
+	cmd := &cobra.Command{
+		Use:     "threaddump <executor-id>",
+		Short:   "Get thread dump for a driver or executor. Requires the application to be running. Use 'driver' for the driver.",
+		Long:    "Get the JVM thread dump for a driver or executor. Use 'driver' for the driver. The application must be running; completed applications return 404 because the Spark History Server does not persist thread dumps.",
+		PreRunE: requireAppID,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := newClient()
+			if err != nil {
+				return err
+			}
+			executorID := args[0]
+
+			resp, err := c.GetExecutorThreadsWithResponse(cmd.Context(), appID, executorID)
+			if err != nil {
+				return err
+			}
+			body, err := util.CheckResponse(resp.JSON200, resp.HTTPResponse.Status)
+			if err != nil {
+				return err
+			}
+			threads := util.Deref(body)
+
+			threads = filterThreads(threads, stateFilter, nameFilter, blockedOnly)
+
+			slices.SortFunc(threads, func(a, b client.ThreadStackTrace) int {
+				return cmp.Compare(util.Deref(a.ThreadId), util.Deref(b.ThreadId))
+			})
+
+			return util.PrintOutput(cmd.OutOrStdout(), threads, outputFmt, func(w io.Writer) error {
+				rows := make([]threadRow, len(threads))
+				for i, t := range threads {
+					rows[i] = threadRow{
+						ID:        util.Deref(t.ThreadId),
+						Name:      util.Deref(t.ThreadName),
+						State:     util.Deref(t.ThreadState),
+						Daemon:    util.Deref(t.IsDaemon),
+						BlockedBy: util.Deref(t.BlockedByThreadId),
+						Lock:      util.Deref(t.LockName),
+					}
+				}
+				if err := util.PrintTable(w, rows); err != nil {
+					return err
+				}
+				_, _ = fmt.Fprintf(w, "\n%d threads (use -o json|yaml for full stack traces)\n", len(threads))
+				return nil
+			})
+		},
+	}
+
+	cmd.Flags().StringVar(&stateFilter, "state", "", "Filter by thread state (RUNNABLE|BLOCKED|WAITING|TIMED_WAITING|...)")
+	cmd.Flags().StringVar(&nameFilter, "name", "", "Filter by substring match on thread name (case-insensitive)")
+	cmd.Flags().BoolVar(&blockedOnly, "blocked-only", false, "Show only threads blocked on a lock or another thread")
+	return cmd
+}
+
+func filterThreads(threads []client.ThreadStackTrace, state, name string, blockedOnly bool) []client.ThreadStackTrace {
+	if state == "" && name == "" && !blockedOnly {
+		return threads
+	}
+	nameLow := strings.ToLower(name)
+	out := make([]client.ThreadStackTrace, 0, len(threads))
+	for _, t := range threads {
+		if state != "" && !strings.EqualFold(util.Deref(t.ThreadState), state) {
+			continue
+		}
+		if nameLow != "" && !strings.Contains(strings.ToLower(util.Deref(t.ThreadName)), nameLow) {
+			continue
+		}
+		if blockedOnly && t.BlockedByThreadId == nil && t.LockName == nil {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}

--- a/skills/cli/cmd/threaddump_test.go
+++ b/skills/cli/cmd/threaddump_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/kubeflow/mcp-apache-spark-history-server/skills/cli/client"
+)
+
+func strPtr(s string) *string { return &s }
+func int64Ptr(i int64) *int64 { return &i }
+
+func sampleThreads() []client.ThreadStackTrace {
+	return []client.ThreadStackTrace{
+		{
+			ThreadId:    int64Ptr(1),
+			ThreadName:  strPtr("main"),
+			ThreadState: strPtr("RUNNABLE"),
+		},
+		{
+			ThreadId:          int64Ptr(2),
+			ThreadName:        strPtr("dispatcher-event-loop-0"),
+			ThreadState:       strPtr("WAITING"),
+			BlockedByThreadId: int64Ptr(1),
+		},
+		{
+			ThreadId:    int64Ptr(3),
+			ThreadName:  strPtr("Executor task launch worker for task 42"),
+			ThreadState: strPtr("BLOCKED"),
+			LockName:    strPtr("java.util.concurrent.locks.ReentrantLock"),
+		},
+		{
+			ThreadId:    int64Ptr(4),
+			ThreadName:  strPtr("DispatcherWatcher"),
+			ThreadState: strPtr("TIMED_WAITING"),
+		},
+	}
+}
+
+func TestFilterThreads(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       string
+		nameFilter  string
+		blockedOnly bool
+		wantIDs     []int64
+	}{
+		{
+			name:    "no filter returns all",
+			wantIDs: []int64{1, 2, 3, 4},
+		},
+		{
+			name:    "state RUNNABLE",
+			state:   "RUNNABLE",
+			wantIDs: []int64{1},
+		},
+		{
+			name:    "state lowercase still matches",
+			state:   "blocked",
+			wantIDs: []int64{3},
+		},
+		{
+			name:       "name substring case-insensitive",
+			nameFilter: "DISPATCHER",
+			wantIDs:    []int64{2, 4},
+		},
+		{
+			name:        "blocked-only catches BlockedByThreadId",
+			blockedOnly: true,
+			wantIDs:     []int64{2, 3},
+		},
+		{
+			name:       "combine state + name",
+			state:      "WAITING",
+			nameFilter: "dispatcher",
+			wantIDs:    []int64{2},
+		},
+		{
+			name:       "no match returns empty",
+			nameFilter: "nonexistent",
+			wantIDs:    []int64{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterThreads(sampleThreads(), tt.state, tt.nameFilter, tt.blockedOnly)
+			gotIDs := make([]int64, len(got))
+			for i, th := range got {
+				gotIDs[i] = *th.ThreadId
+			}
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Fatalf("got IDs %v, want %v", gotIDs, tt.wantIDs)
+			}
+			for i, id := range tt.wantIDs {
+				if gotIDs[i] != id {
+					t.Errorf("index %d: got %d, want %d", i, gotIDs[i], id)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description
Add `shs threaddump <executor-id>` to fetch JVM thread dumps from the live Spark driver UI via /applications/{app}/executors/{id}/threads. Use 'driver' for the application driver or a numeric id for a specific executor.

Defaults to a thread summary table (id/name/state/daemon/blocked-by/lock); -o json|yaml returns full stack traces. Filtering flags --state, --name (case-insensitive substring), and --blocked-only narrow large dumps.

The endpoint is only served by the live driver UI (or a YARN/standalone proxy in front of it), so the configured server URL must point at a running application; the Spark History Server does not persist thread dumps in event logs and returns 404 for completed apps.
