### PR TITLE
CLI Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cli.yaml
+++ b/.github/workflows/ci-cli.yaml
@@ -8,6 +8,9 @@ on:
     branches: [main]
     paths: ['skills/cli/**']
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint & E2E


### PR DESCRIPTION
Potential fix for [https://github.com/kubeflow/mcp-apache-spark-history-server/security/code-scanning/7](https://github.com/kubeflow/mcp-apache-spark-history-server/security/code-scanning/7)

Add an explicit `permissions` block to `.github/workflows/ci-cli.yaml` with the least privilege required.  
Best fix here: define workflow-level permissions right after the `on:` section (or before `jobs:`), setting:

- `contents: read`

This preserves existing functionality (checkout and reading repository contents) while preventing unintended token write access. No imports, methods, or dependencies are needed—just YAML configuration in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
