### PR TITLE
Refactor SQL tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Agents can target a specific server per query:
 | **Strands Agents** | streamable-http | [Setup →](examples/integrations/strands-agents/) |
 | **Local / Inspector** | streamable-http | [Setup →](TESTING.md) |
 
-### Available Tools (21)
+### Available Tools (22)
 
 <details>
 <summary>Available Tools</summary>
@@ -234,9 +234,10 @@ Agents can target a specific server per query:
 #### SQL & Query Analysis
 | Tool | Description |
 |------|-------------|
-| `list_slowest_sql_queries` | Top N slowest SQL executions with metrics |
-| `get_sql_execution` | SQL execution detail with optional plan and node metrics |
-| `compare_sql_execution_plans` | Compare SQL plans and metrics between two jobs |
+| `list_sql_executions` | List SQL executions as curated summaries, with status/description filters, sorting, and a default limit |
+| `get_sql_execution` | SQL execution header by default; opt-in plan, node metrics, job summaries, aggregated stage metrics, and stage list |
+| `compare_sql_executions` | Compare aggregated performance metrics (stages, tasks, shuffle, spill, GC) between two SQL executions |
+| `compare_sql_execution_plans` | Compare SQL plan structure (node types, node/edge counts) between two executions |
 
 #### Performance & Bottleneck Analysis
 | Tool | Description |
@@ -263,7 +264,7 @@ Agents can target a specific server per query:
 - *"Why is my ETL job running slower than yesterday?"* → `get_job_bottlenecks` + `list_slowest_stages` + `compare_job_performance`
 - *"What caused job 42 to fail?"* → `list_jobs` + `get_stage` + `get_stage_task_summary`
 - *"Compare today's batch with yesterday's run"* → `compare_job_performance` + `compare_job_environments`
-- *"Find my slowest SQL queries and explain why"* → `list_slowest_sql_queries` + `get_sql_execution` + `compare_sql_execution_plans`
+- *"Find my slowest SQL queries and explain why"* → `list_sql_executions` + `get_sql_execution` + `compare_sql_executions`
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -80,35 +80,25 @@ tasks:
       - echo "✅ Helm chart unit tests completed!"
 
   test-e2e:
-    desc: Run end-to-end tests with multiple Spark servers and MCP server
+    desc: Run end-to-end tests against the Spark History Server e2e corpus
     cmds:
-      - echo "🧪 Starting end-to-end tests with multiple Spark servers..."
+      - echo "🧪 Starting end-to-end tests..."
       - echo "Backing up original config..."
       - cp config.yaml config.yaml.backup
       - defer: cp config.yaml.backup config.yaml && rm config.yaml.backup
       - defer:
           task: stop-all
+      - defer:
+          task: cli:stop-shs
       - echo "Setting up e2e configuration..."
       - cp tests/config-e2e.yaml config.yaml
+      - echo "Starting Spark History Server..."
+      - task: cli:start-shs
+      - echo "Starting MCP server..."
       - task: start-mcp-bg
-      - echo "Starting first Spark server..."
-      - task: start-spark-bg
-        vars:
-          CONTAINER_NAME: "spark-server-1"
-          PORT: "18080"
-          EVENT_DIR: "examples/basic"
-      - echo "Starting second Spark server..."
-      - task: start-spark-bg
-        vars:
-          CONTAINER_NAME: "spark-server-2"
-          PORT: "18081"
-          EVENT_DIR: "examples/basic2"
-        silent: false
-      - echo "Both servers started, running tests..."
       - |
         echo "Running e2e tests..."
         uv run pytest tests/e2e.py -v
-      - task: stop-all
 
   test-verbose:
     desc: Run tests with verbose output

--- a/src/spark_history_mcp/models/mcp_types.py
+++ b/src/spark_history_mcp/models/mcp_types.py
@@ -1,27 +1,156 @@
-from typing import Optional, Sequence
+"""Curated, LLM-friendly output models for MCP tools.
+
+These intentionally expose a small, summarized subset of the raw Spark History
+Server payloads.
+"""
+
+from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class JobSummary(BaseModel):
-    """Summary of job execution counts for a SQL query."""
+class SqlExecutionSummary(BaseModel):
+    """Header-level summary of a single SQL execution."""
 
-    success_job_ids: Sequence[int] = Field(..., alias="successJobsIds")
-    failed_job_ids: Sequence[int] = Field(..., alias="failedJobsIds")
-    running_job_ids: Sequence[int] = Field(..., alias="runningJobsIds")
+    id: Optional[int] = None
+    status: Optional[str] = None
+    description: Optional[str] = None
+    submission_time: Optional[str] = Field(None, alias="submissionTime")
+    duration: Optional[int] = None  # milliseconds, as reported by SHS
+    success_job_ids: List[int] = Field(default_factory=list, alias="successJobIds")
+    failed_job_ids: List[int] = Field(default_factory=list, alias="failedJobIds")
+    running_job_ids: List[int] = Field(default_factory=list, alias="runningJobIds")
 
     model_config = ConfigDict(populate_by_name=True)
 
 
-class SqlQuerySummary(BaseModel):
-    """Simplified summary of a SQL query execution for LLM consumption."""
+class SqlNodeMetrics(BaseModel):
+    """Per-node plan metrics, keyed name -> value."""
 
-    id: int
-    duration: Optional[int] = None  # Duration in milliseconds
+    node_id: Optional[int] = Field(None, alias="nodeId")
+    node_name: Optional[str] = Field(None, alias="nodeName")
+    metrics: dict[str, str] = Field(default_factory=dict)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlJobSummary(BaseModel):
+    """Curated job row associated with a SQL execution."""
+
+    job_id: Optional[int] = Field(None, alias="jobId")
+    status: Optional[str] = None
     description: Optional[str] = None
-    status: str
-    submission_time: Optional[str] = Field(None, alias="submissionTime")
-    plan_description: str = Field(..., alias="planDescription")
-    job_summary: JobSummary = Field(..., alias="jobSummary")
+    duration: Optional[int] = None  # milliseconds
+    num_tasks: Optional[int] = Field(None, alias="numTasks")
+    num_failed_tasks: Optional[int] = Field(None, alias="numFailedTasks")
+    stage_ids: List[int] = Field(default_factory=list, alias="stageIds")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlStageSummary(BaseModel):
+    """Curated stage row associated with a SQL execution."""
+
+    stage_id: Optional[int] = Field(None, alias="stageId")
+    attempt_id: Optional[int] = Field(None, alias="attemptId")
+    status: Optional[str] = None
+    description: Optional[str] = None
+    num_tasks: Optional[int] = Field(None, alias="numTasks")
+    num_failed_tasks: Optional[int] = Field(None, alias="numFailedTasks")
+    duration: Optional[int] = None  # milliseconds
+    input_bytes: Optional[int] = Field(None, alias="inputBytes")
+    shuffle_read_bytes: Optional[int] = Field(None, alias="shuffleReadBytes")
+    shuffle_write_bytes: Optional[int] = Field(None, alias="shuffleWriteBytes")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class StageMetricsAggregation(BaseModel):
+    """Aggregated stage metrics scoped to a SQL execution."""
+
+    stage_count: int = Field(0, alias="stageCount")
+    tasks: int = 0
+    duration: int = 0  # milliseconds (sum of per-stage wall durations)
+    input_bytes: int = Field(0, alias="inputBytes")
+    shuffle_read_bytes: int = Field(0, alias="shuffleReadBytes")
+    shuffle_write_bytes: int = Field(0, alias="shuffleWriteBytes")
+    disk_bytes_spilled: int = Field(0, alias="diskBytesSpilled")
+    jvm_gc_time: int = Field(0, alias="jvmGcTime")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlExecutionDetail(BaseModel):
+    """Detailed view of a SQL execution.
+
+    By default, only ``execution`` (the header) is populated. The optional
+    sections are filled in when the corresponding ``include_*`` flag is set on
+    ``get_sql_execution``.
+    """
+
+    execution: SqlExecutionSummary
+    plan_description: Optional[str] = Field(None, alias="planDescription")
+    node_metrics: Optional[List[SqlNodeMetrics]] = Field(None, alias="nodeMetrics")
+    jobs: Optional[List[SqlJobSummary]] = None
+    stage_metrics: Optional[StageMetricsAggregation] = Field(None, alias="stageMetrics")
+    stages: Optional[List[SqlStageSummary]] = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlCompareSide(BaseModel):
+    """One side of a SQL execution metrics comparison."""
+
+    app: str
+    sql_id: Optional[int] = Field(None, alias="sqlId")
+    description: Optional[str] = None
+    status: Optional[str] = None
+    duration: Optional[int] = None  # milliseconds
+    jobs: int = 0
+    stages: int = 0
+    tasks: int = 0
+    stage_time: int = Field(0, alias="stageTime")  # milliseconds
+    input_bytes: int = Field(0, alias="inputBytes")
+    shuffle_read_bytes: int = Field(0, alias="shuffleReadBytes")
+    shuffle_write_bytes: int = Field(0, alias="shuffleWriteBytes")
+    disk_bytes_spilled: int = Field(0, alias="diskBytesSpilled")
+    jvm_gc_time: int = Field(0, alias="jvmGcTime")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlExecutionComparison(BaseModel):
+    """Metrics diff between two SQL executions."""
+
+    a: SqlCompareSide
+    b: SqlCompareSide
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlNodeTypeDiff(BaseModel):
+    """Count of a single plan node type on each side of a plan comparison."""
+
+    node_type: str = Field(..., alias="nodeType")
+    a: int = 0
+    b: int = 0
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SqlPlanComparison(BaseModel):
+    """Plan-structure diff between two SQL executions."""
+
+    app_a: str = Field(..., alias="appA")
+    app_b: str = Field(..., alias="appB")
+    exec_id_a: Optional[int] = Field(None, alias="execIdA")
+    exec_id_b: Optional[int] = Field(None, alias="execIdB")
+    node_count_a: int = Field(0, alias="nodeCountA")
+    node_count_b: int = Field(0, alias="nodeCountB")
+    edge_count_a: int = Field(0, alias="edgeCountA")
+    edge_count_b: int = Field(0, alias="edgeCountB")
+    node_type_diffs: List[SqlNodeTypeDiff] = Field(
+        default_factory=list, alias="nodeTypeDiffs"
+    )
 
     model_config = ConfigDict(populate_by_name=True)

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -10,8 +10,16 @@ from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
 from spark_history_mcp.core.app import mcp
 from spark_history_mcp.models.mcp_types import (
-    JobSummary,
-    SqlQuerySummary,
+    SqlCompareSide,
+    SqlExecutionComparison,
+    SqlExecutionDetail,
+    SqlExecutionSummary,
+    SqlJobSummary,
+    SqlNodeMetrics,
+    SqlNodeTypeDiff,
+    SqlPlanComparison,
+    SqlStageSummary,
+    StageMetricsAggregation,
 )
 
 from ..utils.utils import parallel_execute
@@ -68,6 +76,143 @@ def _duration_seconds(start: Any, end: Any) -> float:
     if start_dt and end_dt:
         return (end_dt - start_dt).total_seconds()
     return 0
+
+
+def _duration_ms(start: Any, end: Any) -> int:
+    """Return the duration in whole milliseconds between two Spark timestamps."""
+    return int(_duration_seconds(start, end) * 1000)
+
+
+# Lower number = shown first. Anything not listed sorts last, then by duration descending.
+_SQL_STATUS_PRIORITY = {"FAILED": 0, "RUNNING": 1, "COMPLETED": 2}
+_JOB_STATUS_PRIORITY = {"FAILED": 0, "RUNNING": 1, "UNKNOWN": 2, "SUCCEEDED": 3}
+_STAGE_STATUS_PRIORITY = {
+    "FAILED": 0,
+    "COMPLETE": 1,
+    "ACTIVE": 2,
+    "PENDING": 3,
+    "SKIPPED": 4,
+}
+
+
+def _strip_initial_plans(plan: str) -> str:
+    """Remove ``== Initial Plan ==`` sections from an AQE plan description.
+
+    Keeps only the final/current plan.
+    Blocks are detected by the ``+- == Initial Plan ==`` marker and
+    removed along with all lines indented deeper than the marker.
+    """
+    lines = plan.split("\n")
+    out: List[str] = []
+    i = 0
+    while i < len(lines):
+        if lines[i].strip().startswith("+- == Initial Plan =="):
+            marker_indent = len(lines[i]) - len(lines[i].lstrip(" "))
+            i += 1
+            while i < len(lines):
+                line_indent = len(lines[i]) - len(lines[i].lstrip(" "))
+                if lines[i] == "" or line_indent > marker_indent:
+                    i += 1
+                else:
+                    break
+            continue
+        out.append(lines[i])
+        i += 1
+    return "\n".join(out).rstrip("\n")
+
+
+def _collect_sql_job_ids(execution: SQLExecution) -> List[int]:
+    """Return all job IDs (success + failed + running) for a SQL execution."""
+    ids: List[int] = []
+    for group in (
+        execution.success_job_ids,
+        execution.failed_job_ids,
+        execution.running_job_ids,
+    ):
+        if group:
+            ids.extend(group)
+    return ids
+
+
+def _stage_ids_from_jobs(jobs: List[Job]) -> set:
+    """Return the set of stage IDs referenced by the given jobs."""
+    stage_ids: set = set()
+    for job in jobs:
+        if job.stage_ids:
+            stage_ids.update(job.stage_ids)
+    return stage_ids
+
+
+def _aggregate_stages(
+    stages: List[StageData], stage_ids: Optional[set]
+) -> StageMetricsAggregation:
+    """Aggregate stage metrics, optionally scoped to a set of stage IDs.
+
+    De-duplicates by stage ID (keeping the first attempt seen)
+    """
+    agg = StageMetricsAggregation()
+    seen: set = set()
+    for stage in stages:
+        sid = stage.stage_id
+        if (stage_ids is not None and sid not in stage_ids) or sid in seen:
+            continue
+        seen.add(sid)
+        agg.stage_count += 1
+        agg.tasks += stage.num_tasks or 0
+        agg.duration += _duration_ms(stage.submission_time, stage.completion_time)
+        agg.input_bytes += stage.input_bytes or 0
+        agg.shuffle_read_bytes += stage.shuffle_read_bytes or 0
+        agg.shuffle_write_bytes += stage.shuffle_write_bytes or 0
+        agg.disk_bytes_spilled += stage.disk_bytes_spilled or 0
+        agg.jvm_gc_time += stage.jvm_gc_time or 0
+    return agg
+
+
+def _sort_sql_executions(
+    executions: List[SQLExecution], sort_by: Optional[str]
+) -> List[SQLExecution]:
+    def duration(e: SQLExecution) -> int:
+        return e.duration or 0
+
+    if sort_by == "duration":
+        return sorted(executions, key=duration, reverse=True)
+    if sort_by == "id":
+        return sorted(executions, key=lambda e: e.id or 0, reverse=True)
+    # default: failed first, then by duration descending
+    return sorted(
+        executions,
+        key=lambda e: (_SQL_STATUS_PRIORITY.get(e.status, 99), -duration(e)),
+    )
+
+
+def _sort_sql_jobs(jobs: List[Job]) -> List[Job]:
+    """Sort jobs failed-first, then by duration descending."""
+    return sorted(
+        jobs,
+        key=lambda j: (
+            _JOB_STATUS_PRIORITY.get(j.status, 99),
+            -_duration_ms(j.submission_time, j.completion_time),
+        ),
+    )
+
+
+def _sort_sql_stages(stages: List[StageData]) -> List[StageData]:
+    """Sort stages by status priority, then by duration descending."""
+    return sorted(
+        stages,
+        key=lambda s: (
+            _STAGE_STATUS_PRIORITY.get(s.status, 99),
+            -_duration_ms(s.submission_time, s.completion_time),
+        ),
+    )
+
+
+def _count_node_types(nodes) -> Dict[str, int]:
+    """Count plan nodes by node name."""
+    counts: Dict[str, int] = {}
+    for node in nodes or []:
+        counts[node.node_name] = counts.get(node.node_name, 0) + 1
+    return counts
 
 
 def get_client_or_default(
@@ -836,118 +981,71 @@ def compare_sql_execution_plans(
     execution_id1: Optional[int] = None,
     execution_id2: Optional[int] = None,
     server: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> SqlPlanComparison:
     """
-    Compare SQL execution plans between two Spark jobs.
+    Compare the plan structure of two SQL executions.
 
-    Analyzes the logical and physical plans, identifies differences in operations,
-    and compares execution metrics between SQL queries.
+    Compares the SQL plan DAGs of two executions by node type and counts,
+    returning only the node types whose counts differ, plus total node and edge
+    counts for each side.
 
     Args:
         app_id1: First Spark application ID
         app_id2: Second Spark application ID
-        execution_id1: Optional specific execution ID for first app (uses longest if not specified)
-        execution_id2: Optional specific execution ID for second app (uses longest if not specified)
+        execution_id1: Execution ID for the first app (uses longest-running if omitted)
+        execution_id2: Execution ID for the second app (uses longest-running if omitted)
         server: Optional server name to use (uses default if not specified)
 
     Returns:
-        Dictionary containing SQL execution plan comparison
+        SqlPlanComparison with per-side node/edge counts and differing node types
     """
     ctx = mcp.get_context()
     client1 = get_client_or_default(ctx, server, app_id1)
     client2 = get_client_or_default(ctx, server, app_id2)
 
-    # Get SQL executions for both applications
-    sql_execs1 = client1.get_sql_list(
-        app_id=app_id1, details=True, plan_description=True
-    )
-    sql_execs2 = client2.get_sql_list(
-        app_id=app_id2, details=True, plan_description=True
-    )
-
-    # If specific execution IDs not provided, use the longest running ones
-    if execution_id1 is None and sql_execs1:
-        execution_id1 = max(sql_execs1, key=lambda x: x.duration or 0).id
-    if execution_id2 is None and sql_execs2:
-        execution_id2 = max(sql_execs2, key=lambda x: x.duration or 0).id
+    if execution_id1 is None:
+        sql_list1 = client1.get_sql_list(app_id=app_id1, details=False)
+        if sql_list1:
+            execution_id1 = max(sql_list1, key=lambda x: x.duration or 0).id
+    if execution_id2 is None:
+        sql_list2 = client2.get_sql_list(app_id=app_id2, details=False)
+        if sql_list2:
+            execution_id2 = max(sql_list2, key=lambda x: x.duration or 0).id
 
     if execution_id1 is None or execution_id2 is None:
-        return {
-            "error": "No SQL executions found in one or both applications",
-            "app1_sql_count": len(sql_execs1),
-            "app2_sql_count": len(sql_execs2),
-        }
+        raise ValueError("No SQL executions found in one or both applications")
 
-    # Get specific execution details
     exec1 = client1.get_sql_execution(
-        app_id1, execution_id1, details=True, plan_description=True
+        app_id1, execution_id1, details=True, plan_description=False
     )
     exec2 = client2.get_sql_execution(
-        app_id2, execution_id2, details=True, plan_description=True
+        app_id2, execution_id2, details=True, plan_description=False
     )
 
-    # Analyze nodes and operations
-    def analyze_nodes(execution):
-        node_types = {}
-        for node in execution.nodes:
-            node_type = node.node_name
-            if node_type not in node_types:
-                node_types[node_type] = 0
-            node_types[node_type] += 1
-        return node_types
+    nodes1 = _count_node_types(exec1.nodes)
+    nodes2 = _count_node_types(exec2.nodes)
 
-    nodes1 = analyze_nodes(exec1)
-    nodes2 = analyze_nodes(exec2)
+    diffs = [
+        SqlNodeTypeDiff(
+            node_type=node_type,
+            a=nodes1.get(node_type, 0),
+            b=nodes2.get(node_type, 0),
+        )
+        for node_type in sorted(set(nodes1) | set(nodes2))
+        if nodes1.get(node_type, 0) != nodes2.get(node_type, 0)
+    ]
 
-    all_node_types = set(nodes1.keys()) | set(nodes2.keys())
-
-    comparison = {
-        "applications": {"app1": app_id1, "app2": app_id2},
-        "executions": {
-            "app1": {
-                "execution_id": execution_id1,
-                "duration": exec1.duration,
-                "status": exec1.status,
-                "node_count": len(exec1.nodes),
-                "edge_count": len(exec1.edges),
-            },
-            "app2": {
-                "execution_id": execution_id2,
-                "duration": exec2.duration,
-                "status": exec2.status,
-                "node_count": len(exec2.nodes),
-                "edge_count": len(exec2.edges),
-            },
-        },
-        "plan_structure": {
-            "node_type_comparison": {
-                node_type: {
-                    "app1_count": nodes1.get(node_type, 0),
-                    "app2_count": nodes2.get(node_type, 0),
-                }
-                for node_type in sorted(all_node_types)
-            },
-            "complexity_metrics": {
-                "node_count_ratio": len(exec2.nodes) / max(len(exec1.nodes), 1),
-                "edge_count_ratio": len(exec2.edges) / max(len(exec1.edges), 1),
-                "duration_ratio": (exec2.duration or 0) / max(exec1.duration or 1, 1),
-            },
-        },
-        "job_associations": {
-            "app1": {
-                "running_jobs": exec1.running_job_ids,
-                "success_jobs": exec1.success_job_ids,
-                "failed_jobs": exec1.failed_job_ids,
-            },
-            "app2": {
-                "running_jobs": exec2.running_job_ids,
-                "success_jobs": exec2.success_job_ids,
-                "failed_jobs": exec2.failed_job_ids,
-            },
-        },
-    }
-
-    return comparison
+    return SqlPlanComparison(
+        app_a=app_id1,
+        app_b=app_id2,
+        exec_id_a=execution_id1,
+        exec_id_b=execution_id2,
+        node_count_a=len(exec1.nodes or []),
+        node_count_b=len(exec2.nodes or []),
+        edge_count_a=len(exec1.edges or []),
+        edge_count_b=len(exec2.edges or []),
+        node_type_diffs=diffs,
+    )
 
 
 @mcp.tool()
@@ -1007,104 +1105,140 @@ def truncate_plan_description(plan_desc: str, max_length: int) -> str:
     return truncated + "\n... [truncated]"
 
 
+def _sql_execution_summary(e: SQLExecution) -> SqlExecutionSummary:
+    """Build the curated header summary for a SQL execution."""
+    return SqlExecutionSummary(
+        id=e.id,
+        status=e.status,
+        description=e.description,
+        submission_time=e.submission_time,
+        duration=e.duration,
+        success_job_ids=e.success_job_ids or [],
+        failed_job_ids=e.failed_job_ids or [],
+        running_job_ids=e.running_job_ids or [],
+    )
+
+
+def _sql_job_summary(j: Job) -> SqlJobSummary:
+    """Build a curated job row associated with a SQL execution."""
+    return SqlJobSummary(
+        job_id=j.job_id,
+        status=j.status,
+        description=j.description or j.name,
+        duration=_duration_ms(j.submission_time, j.completion_time),
+        num_tasks=j.num_tasks,
+        num_failed_tasks=j.num_failed_tasks,
+        stage_ids=j.stage_ids or [],
+    )
+
+
+def _sql_stage_summary(s: StageData) -> SqlStageSummary:
+    """Build a curated stage row associated with a SQL execution."""
+    return SqlStageSummary(
+        stage_id=s.stage_id,
+        attempt_id=s.attempt_id,
+        status=s.status,
+        description=s.description or s.name,
+        num_tasks=s.num_tasks,
+        num_failed_tasks=s.num_failed_tasks,
+        duration=_duration_ms(s.submission_time, s.completion_time),
+        input_bytes=s.input_bytes,
+        shuffle_read_bytes=s.shuffle_read_bytes,
+        shuffle_write_bytes=s.shuffle_write_bytes,
+    )
+
+
+def _build_node_metrics(nodes) -> List[SqlNodeMetrics]:
+    """Build curated per-node plan metrics, skipping nodes without metrics."""
+    result: List[SqlNodeMetrics] = []
+    for n in nodes or []:
+        if not n.metrics:
+            continue
+        metrics: Dict[str, str] = {}
+        for m in n.metrics:
+            # Collapse internal whitespace in values.
+            metrics[m.name] = " ".join((m.value or "").split())
+        if metrics:
+            result.append(
+                SqlNodeMetrics(
+                    node_id=n.node_id, node_name=n.node_name, metrics=metrics
+                )
+            )
+    return result
+
+
 @mcp.tool()
-def list_slowest_sql_queries(
+def list_sql_executions(
     app_id: str,
     server: Optional[str] = None,
     app_attempt_id: Optional[str] = None,
-    top_n: int = 1,
+    status: Optional[str] = None,
+    description: Optional[str] = None,
+    sort_by: Optional[str] = None,
+    limit: int = 20,
     page_size: int = 100,
-    include_running: bool = False,
-    include_plan_description: Optional[bool] = None,
-    plan_description_max_length: int = 2000,
-) -> List[SqlQuerySummary]:
+) -> List[SqlExecutionSummary]:
     """
-    Get the N slowest SQL queries for a Spark application.
+    List SQL executions for a Spark application as curated summaries.
+
+    Returns a lightweight, summarized row per SQL execution (id, status,
+    description, duration, and associated job IDs) without plan text or
+    node-level details. Use ``get_sql_execution`` for a deep dive into a single
+    execution.
 
     Args:
         app_id: The Spark application ID
         server: Optional server name to use (uses default if not specified)
         app_attempt_id: Optional YARN application attempt ID
-        top_n: Number of slowest queries to return (default: 1)
-        page_size: Number of executions to fetch per page (default: 100)
-        include_running: Whether to include running queries (default: False)
-        include_plan_description: Whether to include execution plans (uses server config if not specified)
-        plan_description_max_length: Max characters for plan description (default: 1500)
+        status: Optional status filter (COMPLETED|RUNNING|FAILED)
+        description: Optional case-insensitive substring filter on the description
+        sort_by: Optional sort field (duration|id). Defaults to failed-first then
+            longest duration.
+        limit: Maximum number of executions to return (default: 20; 0 returns all)
+        page_size: Number of executions to fetch per page from the server (default: 100)
 
     Returns:
-        List of SqlQuerySummary objects for the slowest queries
+        List of SqlExecutionSummary objects
     """
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
-    # Config takes priority: if config is set (True/False), use it; otherwise default to True
-    if client.config.include_plan_description is not None:
-        include_plan_description = client.config.include_plan_description
-    else:
-        include_plan_description = True
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
 
+    # Fetch all executions (lightweight: no plan text, no node details).
     all_executions: List[SQLExecution] = []
     offset = 0
-
-    # Fetch all pages of SQL executions
     while True:
-        executions: List[SQLExecution] = client.get_sql_list(
+        page: List[SQLExecution] = client.get_sql_list(
             app_id=app_id,
             app_attempt_id=app_attempt_id,
-            details=True,
-            plan_description=True,
+            details=False,
+            plan_description=False,
             offset=offset,
             length=page_size,
         )
-
-        if not executions:
+        if not page:
             break
-
-        all_executions.extend(executions)
+        all_executions.extend(page)
         offset += page_size
-
-        # If we got fewer executions than the page size, we've reached the end
-        if len(executions) < page_size:
+        if len(page) < page_size:
             break
 
-    # Filter out running queries if not included
-    if not include_running:
-        all_executions = [e for e in all_executions if e.status != "RUNNING"]
+    if description:
+        needle = description.lower()
+        all_executions = [
+            e for e in all_executions if needle in (e.description or "").lower()
+        ]
+    if status:
+        wanted = status.upper()
+        all_executions = [e for e in all_executions if (e.status or "") == wanted]
 
-    # Get the top N slowest executions
-    slowest_executions = heapq.nlargest(
-        top_n, all_executions, key=lambda e: e.duration or 0
-    )
+    all_executions = _sort_sql_executions(all_executions, sort_by)
+    if limit:
+        all_executions = all_executions[:limit]
 
-    # Create simplified results without additional API calls. Raw object is too verbose.
-    simplified_results = []
-    for execution in slowest_executions:
-        job_summary = JobSummary(
-            success_job_ids=execution.success_job_ids or [],
-            failed_job_ids=execution.failed_job_ids or [],
-            running_job_ids=execution.running_job_ids or [],
-        )
-
-        # Handle plan description based on include_plan_description flag
-        plan_description = ""
-        if include_plan_description and execution.plan_description:
-            plan_description = truncate_plan_description(
-                execution.plan_description, plan_description_max_length
-            )
-
-        query_summary = SqlQuerySummary(
-            id=execution.id,
-            duration=execution.duration,
-            description=execution.description,
-            status=execution.status,
-            submission_time=execution.submission_time,
-            plan_description=plan_description,
-            job_summary=job_summary,
-        )
-
-        simplified_results.append(query_summary)
-
-    return simplified_results
+    return [_sql_execution_summary(e) for e in all_executions]
 
 
 @mcp.tool()
@@ -1113,38 +1247,169 @@ def get_sql_execution(
     execution_id: int,
     server: Optional[str] = None,
     app_attempt_id: Optional[str] = None,
-    details: bool = True,
-    plan_description: bool = True,
-) -> SQLExecution:
+    include_plan: Optional[bool] = None,
+    include_initial_plan: bool = False,
+    include_aggregated_metrics: bool = False,
+    include_stages: bool = False,
+    plan_max_length: Optional[int] = None,
+) -> SqlExecutionDetail:
     """
-    Get detailed information about a specific SQL execution.
+    Get details about a specific SQL execution.
 
-    Retrieves comprehensive details of a single SQL execution including its
-    execution plan, associated jobs, metrics, and node-level statistics.
-    This is useful for deep-diving into a specific query's performance after
-    identifying it via list_slowest_sql_queries.
+    By default returns only the curated header (status, duration, associated
+    job IDs) to keep the response small. Additional sections are opt-in:
+
+    * ``include_plan``: physical plan text plus per-node metrics. AQE "Initial
+      Plan" sections are stripped unless ``include_initial_plan`` is set.
+    * ``include_initial_plan``: keep AQE initial plans (implies ``include_plan``).
+    * ``include_aggregated_metrics``: associated jobs plus aggregated stage metrics
+      (tasks, input, shuffle, spill, GC) scoped to this execution.
+    * ``include_stages``: the individual stages for this execution.
 
     Args:
         app_id: The Spark application ID
         execution_id: The SQL execution ID
         server: Optional server name to use (uses default if not specified)
         app_attempt_id: Optional YARN application attempt ID
-        details: Whether to include execution details (default: True)
-        plan_description: Whether to include plan description (default: True)
+        include_plan: Include the plan text and node metrics. If unset, falls back
+            to the server's ``include_plan_description`` config (default False).
+        include_initial_plan: Include AQE initial plans (implies include_plan)
+        include_aggregated_metrics: Include associated jobs and aggregated stage metrics
+        include_stages: Include the individual stages for this execution
+        plan_max_length: Optional max character length for the plan text
 
     Returns:
-        SQLExecution object containing SQL execution details including
-        status, duration, associated job IDs, and execution plan nodes/edges
+        SqlExecutionDetail with the header and any requested sections
     """
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
-    return client.get_sql_execution(
+    # Resolve whether to include the plan. Explicit arg wins; otherwise fall
+    # back to the server's include_plan_description config (default False).
+    if include_initial_plan:
+        include_plan = True
+    elif include_plan is None:
+        config_value = getattr(client.config, "include_plan_description", None)
+        include_plan = bool(config_value) if config_value is not None else False
+
+    # Node-level metrics require details=True; only fetch them when needed.
+    execution = client.get_sql_execution(
         app_id=app_id,
         execution_id=execution_id,
         app_attempt_id=app_attempt_id,
-        details=details,
-        plan_description=plan_description,
+        details=include_plan,
+        plan_description=include_plan,
+    )
+
+    detail = SqlExecutionDetail(execution=_sql_execution_summary(execution))
+
+    if include_plan:
+        plan = execution.plan_description or ""
+        if not include_initial_plan:
+            plan = _strip_initial_plans(plan)
+        if plan_max_length is not None:
+            plan = truncate_plan_description(plan, plan_max_length)
+        detail.plan_description = plan
+        detail.node_metrics = _build_node_metrics(execution.nodes)
+
+    if include_aggregated_metrics or include_stages:
+        job_ids = set(_collect_sql_job_ids(execution))
+        jobs: List[Job] = []
+        stage_list: List[StageData] = []
+        if job_ids:
+            all_jobs = client.list_jobs(app_id=app_id, app_attempt_id=app_attempt_id)
+            jobs = _sort_sql_jobs([j for j in all_jobs if j.job_id in job_ids])
+            stage_ids = _stage_ids_from_jobs(jobs)
+            if stage_ids:
+                all_stages = client.list_stages(
+                    app_id=app_id, app_attempt_id=app_attempt_id
+                )
+                seen: set = set()
+                scoped: List[StageData] = []
+                for s in all_stages:
+                    if s.stage_id in stage_ids and s.stage_id not in seen:
+                        seen.add(s.stage_id)
+                        scoped.append(s)
+                stage_list = _sort_sql_stages(scoped)
+
+        detail.jobs = [_sql_job_summary(j) for j in jobs]
+        if include_aggregated_metrics:
+            detail.stage_metrics = _aggregate_stages(stage_list, None)
+        if include_stages:
+            detail.stages = [_sql_stage_summary(s) for s in stage_list]
+
+    return detail
+
+
+@mcp.tool()
+def compare_sql_executions(
+    app_id1: str,
+    app_id2: str,
+    execution_id1: Optional[int] = None,
+    execution_id2: Optional[int] = None,
+    server: Optional[str] = None,
+) -> SqlExecutionComparison:
+    """
+    Compare performance metrics between two SQL executions.
+
+    For each execution, aggregates the metrics of the stages belonging to that
+    query (jobs, stages, tasks, stage time, input, shuffle read/write, disk
+    spill, GC time) so the two runs can be compared side by side.
+
+    Args:
+        app_id1: First Spark application ID
+        app_id2: Second Spark application ID
+        execution_id1: Execution ID for the first app (uses longest-running if omitted)
+        execution_id2: Execution ID for the second app (uses longest-running if omitted)
+        server: Optional server name to use (uses default if not specified)
+
+    Returns:
+        SqlExecutionComparison with an ``a`` and ``b`` side
+    """
+    ctx = mcp.get_context()
+    client1 = get_client_or_default(ctx, server, app_id1)
+    client2 = get_client_or_default(ctx, server, app_id2)
+
+    def collect_side(
+        client, app_id: str, execution_id: Optional[int]
+    ) -> SqlCompareSide:
+        if execution_id is None:
+            sql_list = client.get_sql_list(app_id=app_id, details=False)
+            if sql_list:
+                execution_id = max(sql_list, key=lambda x: x.duration or 0).id
+        if execution_id is None:
+            raise ValueError(f"No SQL executions found in application {app_id}")
+
+        execution = client.get_sql_execution(
+            app_id, execution_id, details=False, plan_description=False
+        )
+        job_ids = set(_collect_sql_job_ids(execution))
+        all_jobs = client.list_jobs(app_id=app_id)
+        jobs = [j for j in all_jobs if j.job_id in job_ids]
+        stage_ids = _stage_ids_from_jobs(jobs)
+        all_stages = client.list_stages(app_id=app_id)
+        agg = _aggregate_stages(all_stages, stage_ids)
+
+        return SqlCompareSide(
+            app=app_id,
+            sql_id=execution.id,
+            description=execution.description,
+            status=execution.status,
+            duration=execution.duration,
+            jobs=len(jobs),
+            stages=agg.stage_count,
+            tasks=agg.tasks,
+            stage_time=agg.duration,
+            input_bytes=agg.input_bytes,
+            shuffle_read_bytes=agg.shuffle_read_bytes,
+            shuffle_write_bytes=agg.shuffle_write_bytes,
+            disk_bytes_spilled=agg.disk_bytes_spilled,
+            jvm_gc_time=agg.jvm_gc_time,
+        )
+
+    return SqlExecutionComparison(
+        a=collect_side(client1, app_id1, execution_id1),
+        b=collect_side(client2, app_id2, execution_id2),
     )
 
 

--- a/tests/config-e2e.yaml
+++ b/tests/config-e2e.yaml
@@ -1,10 +1,11 @@
-# E2E Test Configuration - Multiple Spark History Servers
+# E2E Test Configuration - shared CLI e2e Spark History Server corpus
+# Both server entries point at the same SHS instance (served by `task cli:start-shs`) for comparison across servers
 servers:
   local:
     default: true
     url: "http://localhost:18080"
-  local2:
-    url: "http://localhost:18081"
+  secondary:
+    url: "http://localhost:18080"
 
 mcp:
   transports:

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -9,10 +9,21 @@ from mcp.types import TextContent
 
 from spark_history_mcp.api_client.models.application import Application
 from spark_history_mcp.api_client.models.job import Job
+from spark_history_mcp.models.mcp_types import (
+    SqlExecutionComparison,
+    SqlExecutionDetail,
+    SqlExecutionSummary,
+    SqlPlanComparison,
+)
 
 mcp_endpoint = "http://localhost:18888/mcp/"
-test_app_id = "spark-cc4d115f011443d787f03a71a476a745"
-test_app_id2 = "spark-bcec39f6201b42b9925124595baad262"
+
+# Apps from the shared e2e corpus (see skills/cli/e2e/fixtures.yaml).
+app1_id = "local-1776286786993"  # shs-e2e-app1
+app2_id = "local-1776286804625"  # shs-e2e-app2
+
+# A SQL execution present in both apps: the join + window + aggregation query.
+sql_exec_id = 6
 
 
 class McpClient:
@@ -65,73 +76,274 @@ class McpClient:
         return self
 
 
+def _parse_list(result, model):
+    """Parse a list-returning tool result into a list of model instances."""
+    return [model.model_validate_json(c.text) for c in result.content]
+
+
+def _parse_one(result, model):
+    """Parse a single-object tool result into a model instance."""
+    assert isinstance(result.content[0], TextContent)
+    return model.model_validate_json(result.content[0].text)
+
+
 @pytest.mark.asyncio
 async def test_tools_not_empty():
     async with McpClient() as client:
         tool_result = await client.list_tools()
         assert tool_result, "Tools list should not be empty"
         assert len(tool_result.tools) > 0, "Tools list should contain at least one tool"
+        names = {t.name for t in tool_result.tools}
+        # New curated SQL tools must be registered.
+        assert {
+            "list_sql_executions",
+            "get_sql_execution",
+            "compare_sql_executions",
+            "compare_sql_execution_plans",
+        }.issubset(names)
 
 
 @pytest.mark.asyncio
 async def test_get_application():
     async with McpClient() as client:
-        app_result = await client.call_tool("get_application", {"app_id": test_app_id})
+        app_result = await client.call_tool("get_application", {"app_id": app1_id})
         assert not app_result.isError
-        assert isinstance(app_result.content[0], TextContent), (
-            "get_application should return a TextContent object"
+        app_info = Application.model_validate(json.loads(app_result.content[0].text))
+        assert app_info.id == app1_id
+        assert app_info.name == "shs-e2e-app1"
+
+
+@pytest.mark.asyncio
+async def test_get_application_via_secondary_server():
+    async with McpClient() as client:
+        # Exercise explicit multi-server routing.
+        app_result = await client.call_tool(
+            "get_application", {"app_id": app2_id, "server": "secondary"}
         )
-
-        app_data = json.loads(app_result.content[0].text)
-        app_info = Application.model_validate(app_data)
-
-        # Validate specific fields
-        assert app_info.id == test_app_id
-        assert app_info.name == "NewYorkTaxiData_2025_06_27_03_56_52"
+        assert not app_result.isError
+        app_info = Application.model_validate(json.loads(app_result.content[0].text))
+        assert app_info.id == app2_id
+        assert app_info.name == "shs-e2e-app2"
 
 
 @pytest.mark.asyncio
 async def test_list_jobs_no_filter():
     async with McpClient() as client:
-        # Test with status filter
-        jobs_result = await client.call_tool("list_jobs", {"app_id": test_app_id})
+        jobs_result = await client.call_tool("list_jobs", {"app_id": app1_id})
         assert not jobs_result.isError
-        assert len(jobs_result.content) == 6
-        for content in jobs_result.content:
-            assert isinstance(content, TextContent), (
-                "list_jobs should return a TextContent object"
-            )
-            stage = Job.model_validate_json(content.text)
-            assert stage.status == "SUCCEEDED", "All jobs should have SUCCEEDED status"
+        jobs = [Job.model_validate_json(c.text) for c in jobs_result.content]
+        assert len(jobs) == 23
+        failed = [j for j in jobs if j.status == "FAILED"]
+        assert len(failed) == 1
+        assert failed[0].job_id == 4
 
 
 @pytest.mark.asyncio
 async def test_list_jobs_with_status_filter():
     async with McpClient() as client:
-        # Test with status filter
         jobs_result = await client.call_tool(
-            "list_jobs", {"app_id": test_app_id, "status": ["SUCCEEDED"]}
+            "list_jobs", {"app_id": app1_id, "status": ["FAILED"]}
         )
         assert not jobs_result.isError
-        assert len(jobs_result.content) > 0
-        for content in jobs_result.content:
-            assert isinstance(content, TextContent), (
-                "list_jobs should return a TextContent object"
-            )
-            stage = Job.model_validate_json(content.text)
-            assert stage.status == "SUCCEEDED", "All jobs should have SUCCEEDED status"
+        jobs = [Job.model_validate_json(c.text) for c in jobs_result.content]
+        assert len(jobs) == 1
+        assert jobs[0].status == "FAILED"
+        assert jobs[0].job_id == 4
+
+
+# ---------------------------------------------------------------------------
+# SQL tools
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_list_sql_executions_default_order():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "list_sql_executions", {"app_id": app1_id, "limit": 0}
+        )
+        assert not result.isError
+        execs = _parse_list(result, SqlExecutionSummary)
+        # Default ordering: failed first, then by duration descending.
+        assert [e.id for e in execs] == [2, 8, 6, 0, 1, 3, 7, 9, 4, 5]
+        assert execs[0].status == "FAILED"
+        assert execs[0].id == 2
 
 
 @pytest.mark.asyncio
-async def test_get_application_from_second_server():
+async def test_list_sql_executions_status_filter():
     async with McpClient() as client:
-        # This should automatically discover the app on server 2
-        app_result = await client.call_tool("get_application", {"app_id": test_app_id2})
-        assert not app_result.isError
-        assert isinstance(app_result.content[0], TextContent), (
-            "get_application should return a TextContent object"
+        result = await client.call_tool(
+            "list_sql_executions", {"app_id": app1_id, "status": "FAILED"}
         )
+        assert not result.isError
+        execs = _parse_list(result, SqlExecutionSummary)
+        assert [e.id for e in execs] == [2]
 
-        app_data = json.loads(app_result.content[0].text)
-        app_info = Application.model_validate(app_data)
-        assert app_info.id == test_app_id2
+
+@pytest.mark.asyncio
+async def test_list_sql_executions_description_filter():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "list_sql_executions",
+            {"app_id": app1_id, "description": "createOrReplaceTempView"},
+        )
+        assert not result.isError
+        execs = _parse_list(result, SqlExecutionSummary)
+        assert {e.id for e in execs} == {4, 5}
+
+
+@pytest.mark.asyncio
+async def test_get_sql_execution_header_only():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_sql_execution", {"app_id": app1_id, "execution_id": sql_exec_id}
+        )
+        assert not result.isError
+        detail = _parse_one(result, SqlExecutionDetail)
+        assert detail.execution.id == sql_exec_id
+        assert detail.execution.status == "COMPLETED"
+        assert detail.execution.duration == 1659
+        assert set(detail.execution.success_job_ids) == {8, 9, 10, 11, 12, 13, 14}
+        # Header-only: heavier sections must be absent by default.
+        assert detail.plan_description is None
+        assert detail.node_metrics is None
+        assert detail.jobs is None
+        assert detail.stage_metrics is None
+        assert detail.stages is None
+
+
+@pytest.mark.asyncio
+async def test_get_sql_execution_with_summary():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_sql_execution",
+            {
+                "app_id": app1_id,
+                "execution_id": sql_exec_id,
+                "include_aggregated_metrics": True,
+            },
+        )
+        assert not result.isError
+        detail = _parse_one(result, SqlExecutionDetail)
+        assert detail.jobs is not None
+        assert len(detail.jobs) == 7
+        agg = detail.stage_metrics
+        assert agg is not None
+        assert agg.stage_count == 25
+        assert agg.tasks == 47
+        assert agg.duration == 1188
+        assert agg.input_bytes == 5527592
+        assert agg.shuffle_read_bytes == 7568036
+        assert agg.shuffle_write_bytes == 7556736
+        assert agg.disk_bytes_spilled == 4223661
+        assert agg.jvm_gc_time == 66
+        # Stages list is only included when explicitly requested.
+        assert detail.stages is None
+
+
+@pytest.mark.asyncio
+async def test_get_sql_execution_with_plan():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_sql_execution",
+            {"app_id": app1_id, "execution_id": sql_exec_id, "include_plan": True},
+        )
+        assert not result.isError
+        detail = _parse_one(result, SqlExecutionDetail)
+        assert detail.plan_description
+        # AQE initial plans are stripped unless explicitly requested.
+        assert "Initial Plan" not in detail.plan_description
+        assert detail.node_metrics is not None
+        assert len(detail.node_metrics) > 0
+
+
+@pytest.mark.asyncio
+async def test_get_sql_execution_with_stages():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_sql_execution",
+            {"app_id": app1_id, "execution_id": sql_exec_id, "include_stages": True},
+        )
+        assert not result.isError
+        detail = _parse_one(result, SqlExecutionDetail)
+        assert detail.stages is not None
+        assert len(detail.stages) == 25
+
+
+@pytest.mark.asyncio
+async def test_compare_sql_executions():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "compare_sql_executions",
+            {
+                "app_id1": app1_id,
+                "app_id2": app2_id,
+                "execution_id1": sql_exec_id,
+                "execution_id2": sql_exec_id,
+            },
+        )
+        assert not result.isError
+        cmp = _parse_one(result, SqlExecutionComparison)
+
+        assert cmp.a.app == app1_id
+        assert cmp.a.sql_id == sql_exec_id
+        assert cmp.a.duration == 1659
+        assert cmp.a.jobs == 7
+        assert cmp.a.stages == 25
+        assert cmp.a.tasks == 47
+        assert cmp.a.stage_time == 1188
+        assert cmp.a.input_bytes == 5527592
+        assert cmp.a.shuffle_read_bytes == 7568036
+        assert cmp.a.shuffle_write_bytes == 7556736
+        assert cmp.a.disk_bytes_spilled == 4223661
+        assert cmp.a.jvm_gc_time == 66
+
+        assert cmp.b.app == app2_id
+        assert cmp.b.sql_id == sql_exec_id
+        assert cmp.b.duration == 999
+        assert cmp.b.jobs == 6
+        assert cmp.b.stages == 14
+        assert cmp.b.tasks == 20
+        assert cmp.b.stage_time == 522
+        assert cmp.b.input_bytes == 5527592
+        assert cmp.b.shuffle_read_bytes == 54714
+        assert cmp.b.shuffle_write_bytes == 43049
+        assert cmp.b.disk_bytes_spilled == 0
+        assert cmp.b.jvm_gc_time == 20
+
+
+@pytest.mark.asyncio
+async def test_compare_sql_execution_plans():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "compare_sql_execution_plans",
+            {
+                "app_id1": app1_id,
+                "app_id2": app2_id,
+                "execution_id1": sql_exec_id,
+                "execution_id2": sql_exec_id,
+            },
+        )
+        assert not result.isError
+        cmp = _parse_one(result, SqlPlanComparison)
+
+        assert cmp.app_a == app1_id
+        assert cmp.app_b == app2_id
+        assert cmp.exec_id_a == sql_exec_id
+        assert cmp.exec_id_b == sql_exec_id
+        assert cmp.node_count_a == 37
+        assert cmp.node_count_b == 29
+        assert cmp.edge_count_a == 26
+        assert cmp.edge_count_b == 21
+
+        diffs = {d.node_type: (d.a, d.b) for d in cmp.node_type_diffs}
+        assert diffs == {
+            "AQEShuffleRead": (5, 3),
+            "BroadcastExchange": (0, 1),
+            "BroadcastHashJoin": (0, 1),
+            "Exchange": (5, 3),
+            "Sort": (4, 2),
+            "SortMergeJoin": (1, 0),
+            "WholeStageCodegen (7)": (1, 0),
+            "WholeStageCodegen (8)": (1, 0),
+            "WholeStageCodegen (9)": (1, 0),
+        }

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -8,9 +8,10 @@ from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.sql_execution import SQLExecution
 from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
-from spark_history_mcp.config.config import ServerConfig
 from spark_history_mcp.tools.tools import (
     _calculate_executor_metrics,
+    compare_sql_execution_plans,
+    compare_sql_executions,
     get_application,
     get_client_or_default,
     get_sql_execution,
@@ -20,8 +21,8 @@ from spark_history_mcp.tools.tools import (
     list_executors,
     list_jobs,
     list_slowest_jobs,
-    list_slowest_sql_queries,
     list_slowest_stages,
+    list_sql_executions,
     list_stages,
 )
 
@@ -897,300 +898,391 @@ class TestTools(unittest.TestCase):
         self.assertEqual(result[1].stage_id, 3)  # 4 minutes
         self.assertEqual(result[2].stage_id, 2)  # 3 minutes
 
-    # Tests for list_slowest_sql_queries tool
-    @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_slowest_sql_queries_success(self, mock_get_client):
-        """Test successful SQL query retrieval and sorting"""
-        mock_client = MagicMock()
-
-        # Create mock SQL executions with different durations
-        sql1 = MagicMock(spec=SQLExecution)
-        sql1.id = 1
-        sql1.duration = 5000  # 5 seconds
-        sql1.status = "COMPLETED"
-        sql1.success_job_ids = [1, 2]
-        sql1.failed_job_ids = []
-        sql1.running_job_ids = []
-        sql1.description = "Query 1"
-        sql1.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql1.plan_description = "Sample plan description"
-
-        sql2 = MagicMock(spec=SQLExecution)
-        sql2.id = 2
-        sql2.duration = 10000  # 10 seconds
-        sql2.status = "COMPLETED"
-        sql2.success_job_ids = [3, 4]
-        sql2.failed_job_ids = []
-        sql2.running_job_ids = []
-        sql2.description = "Query 2"
-        sql2.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql2.plan_description = "Sample plan description"
-
-        sql3 = MagicMock(spec=SQLExecution)
-        sql3.id = 3
-        sql3.duration = 2000  # 2 seconds
-        sql3.status = "COMPLETED"
-        sql3.success_job_ids = [5]
-        sql3.failed_job_ids = []
-        sql3.running_job_ids = []
-        sql3.description = "Query 3"
-        sql3.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql3.plan_description = "Sample plan description"
-
-        mock_client.get_sql_list.return_value = [sql1, sql2, sql3]
-        mock_get_client.return_value = mock_client
-
-        result = list_slowest_sql_queries("spark-app-123", top_n=2)
-
-        # Verify results are sorted by duration (descending)
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].duration, 10000)  # Slowest first
-        self.assertEqual(result[1].duration, 5000)  # Second slowest
+    # Tests for list_sql_executions tool
+    def _mk_sql(
+        self,
+        sql_id,
+        duration,
+        status="COMPLETED",
+        description="Query",
+        success=None,
+        failed=None,
+        running=None,
+    ):
+        sql = MagicMock(spec=SQLExecution)
+        sql.id = sql_id
+        sql.duration = duration
+        sql.status = status
+        sql.description = description
+        sql.submission_time = "2025-08-05T00:23:38.607GMT"
+        sql.success_job_ids = success if success is not None else []
+        sql.failed_job_ids = failed if failed is not None else []
+        sql.running_job_ids = running if running is not None else []
+        return sql
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_slowest_sql_queries_exclude_running(self, mock_get_client):
-        """Test SQL query retrieval excluding running queries"""
+    def test_list_sql_executions_sort_by_duration(self, mock_get_client):
+        """list_sql_executions sorts by duration descending and returns summaries"""
         mock_client = MagicMock()
-
-        # Create mock SQL executions with different statuses
-        sql1 = MagicMock(spec=SQLExecution)
-        sql1.id = 1
-        sql1.duration = 5000
-        sql1.status = "RUNNING"
-        sql1.success_job_ids = []
-        sql1.failed_job_ids = []
-        sql1.running_job_ids = [1]
-        sql1.description = "Running Query"
-        sql1.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql1.plan_description = "Running plan description"
-
-        sql2 = MagicMock(spec=SQLExecution)
-        sql2.id = 2
-        sql2.duration = 10000
-        sql2.status = "COMPLETED"
-        sql2.success_job_ids = [2, 3]
-        sql2.failed_job_ids = []
-        sql2.running_job_ids = []
-        sql2.description = "Completed Query"
-        sql2.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql2.plan_description = "Completed plan description"
-
-        mock_client.get_sql_list.return_value = [sql1, sql2]
+        mock_client.get_sql_list.return_value = [
+            self._mk_sql(1, 5000, success=[1, 2]),
+            self._mk_sql(2, 10000, success=[3]),
+            self._mk_sql(3, 2000, success=[4]),
+        ]
         mock_get_client.return_value = mock_client
 
-        # Call the function (include_running=False by default)
-        result = list_slowest_sql_queries("spark-app-123")
+        result = list_sql_executions("spark-app-123", sort_by="duration")
 
-        # Should exclude running query
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].status, "COMPLETED")
-
-    @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_slowest_sql_queries_include_running(self, mock_get_client):
-        """Test SQL query retrieval including running queries"""
-        mock_client = MagicMock()
-
-        sql1 = MagicMock(spec=SQLExecution)
-        sql1.id = 1
-        sql1.duration = 5000
-        sql1.status = "RUNNING"
-        sql1.success_job_ids = []
-        sql1.failed_job_ids = []
-        sql1.running_job_ids = [1]
-        sql1.description = "Running Query"
-        sql1.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql1.plan_description = "Running plan description"
-
-        sql2 = MagicMock(spec=SQLExecution)
-        sql2.id = 2
-        sql2.duration = 10000
-        sql2.status = "COMPLETED"
-        sql2.success_job_ids = [2, 3]
-        sql2.failed_job_ids = []
-        sql2.running_job_ids = []
-        sql2.description = "Completed Query"
-        sql2.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql2.plan_description = "Completed plan description"
-
-        mock_client.get_sql_list.return_value = [sql1, sql2]
-        mock_get_client.return_value = mock_client
-
-        result = list_slowest_sql_queries(
-            "spark-app-123", include_running=True, top_n=2
+        self.assertEqual([r.id for r in result], [2, 1, 3])
+        self.assertEqual(result[0].duration, 10000)
+        self.assertEqual(result[0].success_job_ids, [3])
+        # List view must be lightweight: no plan text or node details fetched.
+        mock_client.get_sql_list.assert_called_with(
+            app_id="spark-app-123",
+            app_attempt_id=None,
+            details=False,
+            plan_description=False,
+            offset=0,
+            length=100,
         )
 
-        # Should include both queries
-        self.assertEqual(len(result), 2)
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_sql_executions_default_sort_failed_first(self, mock_get_client):
+        """Default ordering puts FAILED first, then RUNNING, then COMPLETED"""
+        mock_client = MagicMock()
+        mock_client.get_sql_list.return_value = [
+            self._mk_sql(1, 10000, status="COMPLETED"),
+            self._mk_sql(2, 1000, status="FAILED"),
+            self._mk_sql(3, 5000, status="RUNNING"),
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = list_sql_executions("spark-app-123")
+
+        self.assertEqual([r.status for r in result], ["FAILED", "RUNNING", "COMPLETED"])
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_slowest_sql_queries_empty_result(self, mock_get_client):
-        """Test SQL query retrieval with empty result"""
+    def test_list_sql_executions_status_filter(self, mock_get_client):
+        """status filter keeps only matching executions (case-insensitive)"""
+        mock_client = MagicMock()
+        mock_client.get_sql_list.return_value = [
+            self._mk_sql(1, 5000, status="COMPLETED"),
+            self._mk_sql(2, 1000, status="FAILED"),
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = list_sql_executions("spark-app-123", status="failed")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].status, "FAILED")
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_sql_executions_description_filter(self, mock_get_client):
+        """description filter does a case-insensitive substring match"""
+        mock_client = MagicMock()
+        mock_client.get_sql_list.return_value = [
+            self._mk_sql(1, 5000, description="benchmark q5"),
+            self._mk_sql(2, 1000, description="warmup"),
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = list_sql_executions("spark-app-123", description="BENCHMARK")
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].id, 1)
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_sql_executions_limit(self, mock_get_client):
+        """limit caps the number of returned executions"""
+        mock_client = MagicMock()
+        mock_client.get_sql_list.return_value = [
+            self._mk_sql(i, (10 - i) * 1000) for i in range(10)
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = list_sql_executions("spark-app-123", sort_by="duration", limit=3)
+
+        self.assertEqual(len(result), 3)
+        self.assertEqual([r.duration for r in result], [10000, 9000, 8000])
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_sql_executions_empty(self, mock_get_client):
+        """Empty result returns an empty list"""
         mock_client = MagicMock()
         mock_client.get_sql_list.return_value = []
         mock_get_client.return_value = mock_client
 
-        result = list_slowest_sql_queries("spark-app-123")
+        result = list_sql_executions("spark-app-123")
 
         self.assertEqual(result, [])
 
+    # Tests for get_sql_execution tool
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_slowest_sql_queries_limit(self, mock_get_client):
-        """Test SQL query retrieval with limit"""
+    def test_get_sql_execution_header_only_default(self, mock_get_client):
+        """By default returns only the header and fetches no plan/details"""
         mock_client = MagicMock()
-
-        sql_execs = []
-        for i in range(10):
-            sql = MagicMock(spec=SQLExecution)
-            sql.id = i
-            sql.duration = (10 - i) * 1000  # Decreasing durations
-            sql.status = "COMPLETED"
-            sql.success_job_ids = [i]
-            sql.failed_job_ids = []
-            sql.running_job_ids = []
-            sql.description = f"Query {i}"
-            sql.submission_time = "2025-08-05T00:23:38.607GMT"
-            sql.plan_description = f"Plan description for query {i}"
-            sql_execs.append(sql)
-
-        mock_client.get_sql_list.return_value = sql_execs
-        mock_get_client.return_value = mock_client
-
-        result = list_slowest_sql_queries("spark-app-123", top_n=3)
-
-        # Verify results - should return only 3 queries
-        self.assertEqual(len(result), 3)
-        # Should be sorted by duration (descending)
-        self.assertEqual(result[0].duration, 10000)
-        self.assertEqual(result[1].duration, 9000)
-        self.assertEqual(result[2].duration, 8000)
-
-    @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_list_slowest_sql_queries_uses_server_config_for_plan_description(
-        self, mock_get_client
-    ):
-        """Test that include_plan_description falls back to server config when not provided"""
-        # Setup mock client with server config
-        mock_client = MagicMock()
-        server_config = ServerConfig(
-            url="http://test:18080", include_plan_description=False
+        mock_client.config.include_plan_description = None
+        mock_client.get_sql_execution.return_value = self._mk_sql(
+            42, 12345, description="SELECT * FROM t", success=[1, 2]
         )
-        mock_client.config = server_config
-
-        sql = MagicMock(spec=SQLExecution)
-        sql.id = 1
-        sql.duration = 5000
-        sql.status = "COMPLETED"
-        sql.success_job_ids = [1]
-        sql.failed_job_ids = []
-        sql.running_job_ids = []
-        sql.description = "Test Query"
-        sql.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql.plan_description = "Sample plan description"
-
-        mock_client.get_sql_list.return_value = [sql]
-        mock_get_client.return_value = mock_client
-
-        # Call function without include_plan_description parameter (should use server config)
-        result = list_slowest_sql_queries("spark-app-123")
-
-        # Verify plan description is empty due to server config setting False
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].plan_description, "")
-
-    @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_list_slowest_sql_queries_explicit_override_server_config(
-        self, mock_get_client
-    ):
-        """Test that server config overrides parameter when config is set"""
-        # Setup mock client with server config set to False
-        mock_client = MagicMock()
-        server_config = ServerConfig(
-            url="http://test:18080", include_plan_description=False
-        )
-        mock_client.config = server_config
-
-        sql = MagicMock(spec=SQLExecution)
-        sql.id = 1
-        sql.duration = 5000
-        sql.status = "COMPLETED"
-        sql.success_job_ids = [1]
-        sql.failed_job_ids = []
-        sql.running_job_ids = []
-        sql.description = "Test Query"
-        sql.submission_time = "2025-08-05T00:23:38.607GMT"
-        sql.plan_description = "Sample plan description"
-
-        mock_client.get_sql_list.return_value = [sql]
-        mock_get_client.return_value = mock_client
-
-        # Call function with explicit include_plan_description=True (config should override to False)
-        result = list_slowest_sql_queries(
-            "spark-app-123", include_plan_description=True
-        )
-
-        # Verify plan description is NOT included because server config is False
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].plan_description, "")
-
-    @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_sql_execution_success(self, mock_get_client):
-        """Test get_sql_execution returns execution details"""
-        mock_client = MagicMock()
-        expected = MagicMock(spec=SQLExecution)
-        expected.id = 42
-        expected.status = "COMPLETED"
-        expected.duration = 12345
-        expected.description = "SELECT * FROM table"
-        mock_client.get_sql_execution.return_value = expected
         mock_get_client.return_value = mock_client
 
         result = get_sql_execution("spark-app-123", execution_id=42)
 
-        self.assertEqual(result.id, 42)
-        self.assertEqual(result.status, "COMPLETED")
+        self.assertEqual(result.execution.id, 42)
+        self.assertEqual(result.execution.success_job_ids, [1, 2])
+        self.assertIsNone(result.plan_description)
+        self.assertIsNone(result.node_metrics)
+        self.assertIsNone(result.jobs)
+        self.assertIsNone(result.stage_metrics)
+        self.assertIsNone(result.stages)
         mock_client.get_sql_execution.assert_called_once_with(
             app_id="spark-app-123",
             execution_id=42,
+            app_attempt_id=None,
+            details=False,
+            plan_description=False,
+        )
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_include_plan_strips_initial(self, mock_get_client):
+        """include_plan strips AQE initial plans and returns node metrics"""
+        mock_client = MagicMock()
+        execution = self._mk_sql(7, 5000)
+        execution.plan_description = (
+            "== Physical Plan ==\n"
+            "*(1) Project\n"
+            "+- == Initial Plan ==\n"
+            "   Sort\n"
+            "   +- Exchange\n"
+        )
+        node = MagicMock()
+        node.node_id = 1
+        node.node_name = "Project"
+        metric = MagicMock()
+        metric.name = "rows"
+        metric.value = "  100  "
+        node.metrics = [metric]
+        execution.nodes = [node]
+        mock_client.get_sql_execution.return_value = execution
+        mock_get_client.return_value = mock_client
+
+        result = get_sql_execution("spark-app-123", execution_id=7, include_plan=True)
+
+        self.assertIn("Physical Plan", result.plan_description)
+        self.assertNotIn("Initial Plan", result.plan_description)
+        self.assertEqual(len(result.node_metrics), 1)
+        self.assertEqual(result.node_metrics[0].node_name, "Project")
+        self.assertEqual(result.node_metrics[0].metrics["rows"], "100")
+        mock_client.get_sql_execution.assert_called_once_with(
+            app_id="spark-app-123",
+            execution_id=7,
             app_attempt_id=None,
             details=True,
             plan_description=True,
         )
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_sql_execution_with_attempt_id(self, mock_get_client):
-        """Test get_sql_execution with attempt_id"""
+    def test_get_sql_execution_include_initial_plan_keeps(self, mock_get_client):
+        """include_initial_plan retains initial plans and implies include_plan"""
         mock_client = MagicMock()
-        expected = MagicMock(spec=SQLExecution)
-        expected.id = 10
-        mock_client.get_sql_execution.return_value = expected
+        execution = self._mk_sql(7, 5000)
+        execution.plan_description = (
+            "== Physical Plan ==\n+- == Initial Plan ==\n   Sort\n"
+        )
+        execution.nodes = []
+        mock_client.get_sql_execution.return_value = execution
         mock_get_client.return_value = mock_client
 
         result = get_sql_execution(
-            "spark-app-123", execution_id=10, app_attempt_id="1", details=False
+            "spark-app-123", execution_id=7, include_initial_plan=True
         )
 
-        self.assertEqual(result.id, 10)
+        self.assertIn("Initial Plan", result.plan_description)
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_config_fallback_includes_plan(self, mock_get_client):
+        """When include_plan is unset, the server config default is used"""
+        mock_client = MagicMock()
+        mock_client.config.include_plan_description = True
+        execution = self._mk_sql(7, 5000)
+        execution.plan_description = "== Physical Plan ==\nProject\n"
+        execution.nodes = []
+        mock_client.get_sql_execution.return_value = execution
+        mock_get_client.return_value = mock_client
+
+        result = get_sql_execution("spark-app-123", execution_id=7)
+
+        self.assertIsNotNone(result.plan_description)
         mock_client.get_sql_execution.assert_called_once_with(
             app_id="spark-app-123",
-            execution_id=10,
-            app_attempt_id="1",
-            details=False,
+            execution_id=7,
+            app_attempt_id=None,
+            details=True,
             plan_description=True,
         )
 
     @patch("spark_history_mcp.tools.tools.get_client_or_default")
-    def test_get_sql_execution_not_found(self, mock_get_client):
-        """Test get_sql_execution raises when execution not found"""
+    def test_get_sql_execution_plan_max_length(self, mock_get_client):
+        """plan_max_length truncates the plan text"""
         mock_client = MagicMock()
-        mock_client.get_sql_execution.side_effect = Exception(
-            "SQL execution 999 not found"
-        )
+        execution = self._mk_sql(7, 5000)
+        execution.plan_description = "X" * 500
+        execution.nodes = []
+        mock_client.get_sql_execution.return_value = execution
         mock_get_client.return_value = mock_client
 
-        with self.assertRaises(Exception) as ctx:
-            get_sql_execution("spark-app-123", execution_id=999)
+        result = get_sql_execution(
+            "spark-app-123", execution_id=7, include_plan=True, plan_max_length=50
+        )
 
-        self.assertIn("999", str(ctx.exception))
+        self.assertIn("[truncated]", result.plan_description)
+
+    def _mk_job(self, job_id, status, stage_ids, num_tasks=10, num_failed=0):
+        job = MagicMock(spec=Job)
+        job.job_id = job_id
+        job.status = status
+        job.description = f"job {job_id}"
+        job.name = f"job {job_id}"
+        job.submission_time = "2025-08-05T00:00:00.000GMT"
+        job.completion_time = "2025-08-05T00:00:10.000GMT"
+        job.stage_ids = stage_ids
+        job.num_tasks = num_tasks
+        job.num_failed_tasks = num_failed
+        return job
+
+    def _mk_stage(self, stage_id, status="COMPLETE", tasks=10):
+        stage = MagicMock(spec=StageData)
+        stage.stage_id = stage_id
+        stage.attempt_id = 0
+        stage.status = status
+        stage.description = f"stage {stage_id}"
+        stage.name = f"stage {stage_id}"
+        stage.num_tasks = tasks
+        stage.num_failed_tasks = 0
+        stage.submission_time = "2025-08-05T00:00:00.000GMT"
+        stage.completion_time = "2025-08-05T00:00:05.000GMT"
+        stage.input_bytes = 1000
+        stage.shuffle_read_bytes = 200
+        stage.shuffle_write_bytes = 300
+        stage.disk_bytes_spilled = 50
+        stage.jvm_gc_time = 25
+        return stage
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_include_aggregated_metrics(self, mock_get_client):
+        """include_aggregated_metrics returns associated jobs and aggregated stage metrics"""
+        mock_client = MagicMock()
+        mock_client.config.include_plan_description = None
+        execution = self._mk_sql(7, 5000, success=[1, 2])
+        mock_client.get_sql_execution.return_value = execution
+        mock_client.list_jobs.return_value = [
+            self._mk_job(1, "SUCCEEDED", [10]),
+            self._mk_job(2, "SUCCEEDED", [11]),
+            self._mk_job(3, "SUCCEEDED", [12]),  # not part of this SQL execution
+        ]
+        mock_client.list_stages.return_value = [
+            self._mk_stage(10),
+            self._mk_stage(11),
+            self._mk_stage(12),  # excluded (job 3 not in SQL execution)
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = get_sql_execution(
+            "spark-app-123", execution_id=7, include_aggregated_metrics=True
+        )
+
+        self.assertEqual({j.job_id for j in result.jobs}, {1, 2})
+        self.assertIsNotNone(result.stage_metrics)
+        self.assertEqual(result.stage_metrics.stage_count, 2)
+        self.assertEqual(result.stage_metrics.tasks, 20)
+        self.assertEqual(result.stage_metrics.input_bytes, 2000)
+        self.assertEqual(result.stage_metrics.shuffle_read_bytes, 400)
+        self.assertIsNone(result.stages)
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_sql_execution_include_stages(self, mock_get_client):
+        """include_stages returns the individual stage rows for the execution"""
+        mock_client = MagicMock()
+        mock_client.config.include_plan_description = None
+        execution = self._mk_sql(7, 5000, success=[1])
+        mock_client.get_sql_execution.return_value = execution
+        mock_client.list_jobs.return_value = [self._mk_job(1, "SUCCEEDED", [10, 11])]
+        mock_client.list_stages.return_value = [
+            self._mk_stage(10),
+            self._mk_stage(11),
+        ]
+        mock_get_client.return_value = mock_client
+
+        result = get_sql_execution("spark-app-123", execution_id=7, include_stages=True)
+
+        self.assertIsNotNone(result.stages)
+        self.assertEqual({s.stage_id for s in result.stages}, {10, 11})
+
+    # Tests for compare_sql_executions tool
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_compare_sql_executions(self, mock_get_client):
+        """compare_sql_executions aggregates per-execution stage metrics for each side"""
+        client_a = MagicMock()
+        client_a.get_sql_execution.return_value = self._mk_sql(
+            1, 5000, description="q", success=[1]
+        )
+        client_a.list_jobs.return_value = [self._mk_job(1, "SUCCEEDED", [10])]
+        client_a.list_stages.return_value = [self._mk_stage(10, tasks=10)]
+
+        client_b = MagicMock()
+        client_b.get_sql_execution.return_value = self._mk_sql(
+            2, 8000, description="q", success=[5]
+        )
+        client_b.list_jobs.return_value = [self._mk_job(5, "SUCCEEDED", [20])]
+        client_b.list_stages.return_value = [self._mk_stage(20, tasks=30)]
+
+        mock_get_client.side_effect = [client_a, client_b]
+
+        result = compare_sql_executions("app-a", "app-b", 1, 2)
+
+        self.assertEqual(result.a.app, "app-a")
+        self.assertEqual(result.a.sql_id, 1)
+        self.assertEqual(result.a.duration, 5000)
+        self.assertEqual(result.a.tasks, 10)
+        self.assertEqual(result.b.app, "app-b")
+        self.assertEqual(result.b.sql_id, 2)
+        self.assertEqual(result.b.tasks, 30)
+
+    # Tests for compare_sql_execution_plans tool
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_compare_sql_execution_plans(self, mock_get_client):
+        """compare_sql_execution_plans returns node/edge counts and differing types"""
+
+        def node(name):
+            n = MagicMock()
+            n.node_name = name
+            return n
+
+        exec_a = MagicMock(spec=SQLExecution)
+        exec_a.nodes = [node("Filter"), node("Scan"), node("Scan")]
+        exec_a.edges = [MagicMock(), MagicMock()]
+
+        exec_b = MagicMock(spec=SQLExecution)
+        exec_b.nodes = [node("Filter"), node("Scan")]
+        exec_b.edges = [MagicMock()]
+
+        client_a = MagicMock()
+        client_a.get_sql_execution.return_value = exec_a
+        client_b = MagicMock()
+        client_b.get_sql_execution.return_value = exec_b
+        mock_get_client.side_effect = [client_a, client_b]
+
+        result = compare_sql_execution_plans("app-a", "app-b", 1, 2)
+
+        self.assertEqual(result.app_a, "app-a")
+        self.assertEqual(result.exec_id_a, 1)
+        self.assertEqual(result.node_count_a, 3)
+        self.assertEqual(result.node_count_b, 2)
+        self.assertEqual(result.edge_count_a, 2)
+        self.assertEqual(result.edge_count_b, 1)
+        diffs = {d.node_type: (d.a, d.b) for d in result.node_type_diffs}
+        self.assertEqual(diffs, {"Scan": (2, 1)})
 
     # Tests for pagination support
 


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

Currently, the CLI offers more versatile, token efficient output than MCP. This is the first PR to address the gap. We need to update and consolidate tools too. 

- Reworked SQL tools into curated, context-efficient shapes (list/get/compare executions + plans)
- Converged MCP e2e tests onto the shared CLI corpus with full SQL coverage
- Updated docs: README tool listing + CLI/MCP parity-gap doc

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

