### PR TITLE
add configuration resolution logic for mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,52 @@ spark-mcp
 
 The package is published to [PyPI](https://pypi.org/project/mcp-apache-spark-history-server/).
 
+### Coding Agent Integration
+
+Register the server with a single command. Both examples run it over **stdio** via `uvx`.
+With no config file present, the server defaults to a Spark History Server at `http://localhost:18080`;
+point it elsewhere with a [config file](#config-file-location) or `SHS_SERVERS_LOCAL_URL`.
+
+**Claude Code** (`claude mcp add`):
+
+```bash
+claude mcp add --env SHS_MCP_TRANSPORT=stdio --transport stdio spark-history \
+  -- uvx --from mcp-apache-spark-history-server spark-mcp
+```
+
+**Kiro CLI** (`kiro-cli mcp add`):
+
+```bash
+kiro-cli mcp add --name spark-history --command uvx \
+  --args --from --args mcp-apache-spark-history-server --args spark-mcp \
+  --env SHS_MCP_TRANSPORT=stdio
+```
+
+Verify in either client with `claude mcp list` / `kiro-cli mcp list`, then ask the agent to *"list the available Spark applications."*
+
+#### Passing server flags and environment
+
+The commands above have two layers: the **client's** own options and the arguments/environment forwarded to **`spark-mcp`**. `spark-mcp` itself takes a single flag, `--config` / `-c`; everything else is set through `SHS_*` [environment variables](#configure).
+
+| To pass to `spark-mcp`… | Claude Code | Kiro CLI |
+|---|---|---|
+| A flag (e.g. `--config`) | append after `--`: `… spark-mcp --config /path/config.yaml` | add `--args` pairs: `--args --config --args /path/config.yaml` |
+| An environment variable | `--env KEY=value` (before `--transport`) | `--env KEY=value` |
+
+For example, to point at a remote Spark History Server with an explicit config file:
+
+```bash
+# Claude Code
+claude mcp add --env SHS_MCP_TRANSPORT=stdio --transport stdio spark-history \
+  -- uvx --from mcp-apache-spark-history-server spark-mcp --config ~/.config/spark-mcp/config.yaml
+
+# Kiro CLI
+kiro-cli mcp add --name spark-history --command uvx \
+  --args --from --args mcp-apache-spark-history-server --args spark-mcp \
+  --args --config --args ~/.config/spark-mcp/config.yaml \
+  --env SHS_MCP_TRANSPORT=stdio
+```
+
 ### Configure
 
 Basic configuration below. Create a file named `config.yaml`:
@@ -144,6 +190,19 @@ mcp:
   port: "18888"
   debug: false
 ```
+
+#### Config file location
+
+The server looks for its config file in the following order and uses the first one it finds:
+
+1. The `--config` / `-c` flag (e.g. `spark-mcp --config /path/to/config.yaml`)
+2. The `SHS_MCP_CONFIG` environment variable
+3. `./config.yaml` in the current working directory
+4. `~/.config/spark-mcp/config.yaml` (honors `$XDG_CONFIG_HOME` when set)
+
+If none exist, the server starts with built-in defaults that can be overridden by `SHS_*` environment variables. When a path is given explicitly via the flag or `SHS_MCP_CONFIG` but the file is missing, the server fails fast instead of falling back.
+
+> **Tip for MCP clients:** when the server is launched by an MCP client (Claude Desktop, Kiro, etc.), the working directory is not guaranteed, so a `./config.yaml` may not be found. Prefer `--config` / `SHS_MCP_CONFIG`, or place the file at `~/.config/spark-mcp/config.yaml`.
 
 Configurations can be overriden with environment variables.
 

--- a/src/spark_history_mcp/config/config.py
+++ b/src/spark_history_mcp/config/config.py
@@ -1,4 +1,6 @@
+import logging
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import yaml
@@ -10,13 +12,45 @@ from pydantic_settings import (
     SettingsConfigDict,
 )
 
+logger = logging.getLogger(__name__)
+
+# Per-user config lives at ~/.config/spark-mcp/config.yaml.
+DEFAULT_CONFIG_FILENAME = "config.yaml"
+APP_CONFIG_DIR = "spark-mcp"
+
+
+def user_config_path() -> str:
+    """Per-user config path: $XDG_CONFIG_HOME (if set) or ~/.config."""
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return os.path.join(xdg_config_home, APP_CONFIG_DIR, DEFAULT_CONFIG_FILENAME)
+
+
+def resolve_config_path() -> Tuple[Optional[str], bool]:
+    """Resolve which config file to load, highest precedence first.
+
+    1. ``SHS_MCP_CONFIG`` env var / ``--config`` flag (explicit)
+    2. ``./config.yaml``
+    3. ``~/.config/spark-mcp/config.yaml``
+
+    Returns ``(path, is_explicit)``; ``path`` is ``None`` when nothing is found
+    (use defaults) and ``is_explicit`` marks a missing file as fatal.
+    """
+    explicit_path = os.getenv("SHS_MCP_CONFIG")
+    if explicit_path:
+        return explicit_path, True
+
+    if os.path.exists(DEFAULT_CONFIG_FILENAME):
+        return DEFAULT_CONFIG_FILENAME, False
+
+    user_path = user_config_path()
+    if os.path.exists(user_path):
+        return user_path, False
+
+    return None, False
+
 
 class YamlConfigSettingsSource(PydanticBaseSettingsSource):
-    """Custom settings source that loads configuration from a YAML file.
-
-    The file path is determined by the SHS_MCP_CONFIG environment variable,
-    defaulting to 'config.yaml' if not set.
-    """
+    """Settings source that loads YAML located via :func:`resolve_config_path`."""
 
     def get_field_value(
         self, field: FieldInfo, field_name: str
@@ -26,17 +60,18 @@ class YamlConfigSettingsSource(PydanticBaseSettingsSource):
 
     def __call__(self) -> Dict[str, Any]:
         """Load and return the YAML configuration data."""
-        config_path = os.getenv("SHS_MCP_CONFIG", "config.yaml")
-        is_explicitly_set = "SHS_MCP_CONFIG" in os.environ
+        config_path, is_explicit = resolve_config_path()
+
+        if config_path is None:
+            return {}
 
         if not os.path.exists(config_path):
-            # If the config file was explicitly specified but doesn't exist, fail fast
-            if is_explicitly_set:
+            # Explicitly requested but missing -> fatal; discovered -> defaults.
+            if is_explicit:
                 raise FileNotFoundError(
                     f"Config file not found: {config_path}\n"
-                    f"Specified via: SHS_MCP_CONFIG environment variable"
+                    f"Specified via: --config flag or SHS_MCP_CONFIG environment variable"
                 )
-            # If using default and it doesn't exist, return empty (will use defaults)
             return {}
 
         with open(config_path, "r") as f:
@@ -51,6 +86,8 @@ class AuthConfig(BaseSettings):
     username: Optional[str] = Field(None)
     password: Optional[str] = Field(None)
     token: Optional[str] = Field(None)
+    # Ignore unknown keys for compatibility with the shared shs CLI config.
+    model_config = SettingsConfigDict(extra="ignore")
 
 
 class ServerConfig(BaseSettings):
@@ -64,6 +101,8 @@ class ServerConfig(BaseSettings):
     use_proxy: bool = False
     timeout: int = 30  # HTTP request timeout in seconds
     include_plan_description: Optional[bool] = None
+    # Ignore unknown keys for compatibility with the shared shs CLI config.
+    model_config = SettingsConfigDict(extra="ignore")
 
 
 class TransportSecurityConfig(BaseSettings):
@@ -94,7 +133,7 @@ class McpConfig(BaseSettings):
     """Configuration for the MCP server."""
 
     transports: List[Literal["stdio", "sse", "streamable-http"]] = Field(
-        default_factory=list
+        default_factory=lambda: ["streamable-http"]
     )
     address: Optional[str] = "localhost"
     port: Optional[int | str] = "18888"

--- a/src/spark_history_mcp/core/main.py
+++ b/src/spark_history_mcp/core/main.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 
-from spark_history_mcp.config.config import Config
+from spark_history_mcp.config.config import Config, resolve_config_path
 from spark_history_mcp.core import app
 
 # Configure logging
@@ -22,19 +22,32 @@ def main():
     parser.add_argument(
         "--config",
         "-c",
-        default=os.getenv("SHS_MCP_CONFIG", "config.yaml"),
-        help="Path to config file (default: config.yaml, env: SHS_MCP_CONFIG)",
+        default=None,
+        help=(
+            "Path to config file. If omitted, the server searches "
+            "$SHS_MCP_CONFIG, then ./config.yaml, then "
+            "~/.config/spark-mcp/config.yaml (env: SHS_MCP_CONFIG)."
+        ),
     )
     args = parser.parse_args()
 
     try:
         logger.info("Starting Spark History Server MCP...")
-        logger.info(f"Using config file: {args.config}")
 
-        # Set the config file path in environment for Pydantic Settings
-        os.environ["SHS_MCP_CONFIG"] = args.config
+        # An explicit --config flag wins over a pre-existing SHS_MCP_CONFIG;
+        # if omitted, leave the env untouched so discovery can run.
+        if args.config is not None:
+            os.environ["SHS_MCP_CONFIG"] = args.config
 
-        # Now Config() will automatically load from the specified YAML file
+        config_path, _ = resolve_config_path()
+        if config_path is not None:
+            logger.info(f"Using config file: {config_path}")
+        else:
+            logger.info(
+                "No config file found; using built-in defaults and SHS_* env vars"
+            )
+
+        # Now Config() will automatically load using the resolution cascade
         config = Config()
         if config.mcp.debug:
             logger.setLevel(logging.DEBUG)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -21,7 +21,7 @@ class TestConfig(unittest.TestCase):
         # Sample config data for testing
         self.config_data = {
             "servers": {
-                "test_server": {
+                "testserver": {
                     "url": "http://test-server:18080",
                     "auth": {"username": "test_user", "password": "test_pass"},
                     "default": True,
@@ -57,8 +57,8 @@ class TestConfig(unittest.TestCase):
             self.assertFalse(config.mcp.debug)
 
             # Verify server config
-            self.assertIn("test_server", config.servers)
-            server = config.servers["test_server"]
+            self.assertIn("testserver", config.servers)
+            server = config.servers["testserver"]
             self.assertEqual(server.url, "http://test-server:18080")
             self.assertEqual(server.auth.username, "test_user")
             self.assertEqual(server.auth.password, "test_pass")
@@ -80,14 +80,19 @@ class TestConfig(unittest.TestCase):
             "SHS_MCP_ADDRESS": "env_host",
             "SHS_MCP_PORT": "8888",
             "SHS_MCP_DEBUG": "true",
-            "SHS_SERVERS_ENV_SERVER_URL": "http://env-server:18080",
-            "SHS_SERVERS_ENV_SERVER_AUTH_USERNAME": "env_user",
-            "SHS_SERVERS_ENV_SERVER_AUTH_PASSWORD": "env_pass",
-            "SHS_SERVERS_ENV_SERVER_DEFAULT": "true",
+            "SHS_SERVERS_ENVSERVER_URL": "http://env-server:18080",
+            "SHS_SERVERS_ENVSERVER_AUTH_USERNAME": "env_user",
+            "SHS_SERVERS_ENVSERVER_AUTH_PASSWORD": "env_pass",
+            "SHS_SERVERS_ENVSERVER_DEFAULT": "true",
         },
     )
     def test_config_from_env_vars(self):
-        """Test loading configuration from environment variables."""
+        """Test loading configuration from environment variables.
+
+        Note: server names must not contain underscores because the settings
+        env_nested_delimiter is '_'. ``SHS_SERVERS_ENVSERVER_URL`` maps to
+        ``servers.envserver.url``.
+        """
         # Create minimal config with empty servers dict to be populated from env
         minimal_config = {"servers": {}}
 
@@ -105,8 +110,8 @@ class TestConfig(unittest.TestCase):
             self.assertTrue(config.mcp.debug)
 
             # Verify server config from env vars
-            self.assertIn("env_server", config.servers)
-            server = config.servers["env_server"]
+            self.assertIn("envserver", config.servers)
+            server = config.servers["envserver"]
             self.assertEqual(server.url, "http://env-server:18080")
             self.assertEqual(server.auth.username, "env_user")
             self.assertEqual(server.auth.password, "env_pass")
@@ -119,8 +124,8 @@ class TestConfig(unittest.TestCase):
         {
             "SHS_MCP_ADDRESS": "override_host",
             "SHS_MCP_PORT": "7777",
-            "SHS_SERVERS_TEST_SERVER_URL": "http://override-server:18080",
-            "SHS_SERVERS_TEST_SERVER_AUTH_USERNAME": "override_user",
+            "SHS_SERVERS_TESTSERVER_URL": "http://override-server:18080",
+            "SHS_SERVERS_TESTSERVER_AUTH_USERNAME": "override_user",
         },
     )
     def test_env_vars_override_file_config(self):
@@ -138,7 +143,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.mcp.port, "7777")
 
             # Verify that server config is overridden
-            server = config.servers["test_server"]
+            server = config.servers["testserver"]
             self.assertEqual(server.url, "http://override-server:18080")
             self.assertEqual(server.auth.username, "override_user")
 
@@ -183,11 +188,11 @@ class TestConfig(unittest.TestCase):
         auth = AuthConfig(username="test_user", password="")
         server = ServerConfig(url="http://test:18080", auth=auth)
 
-        # Test that auth is excluded from serialization
+        # auth is declared with exclude=True, so it must not appear in a dump.
         server_dict = server.model_dump()
-        self.assertIn("auth", server_dict)
+        self.assertNotIn("auth", server_dict)
 
-        # Test with explicit exclude
+        # Explicitly excluding it as well keeps it absent.
         server_dict = server.model_dump(exclude={"auth"})
         self.assertNotIn("auth", server_dict)
 
@@ -270,7 +275,7 @@ class TestTransportSecurityConfig(unittest.TestCase):
             os.unlink(temp_file_path)
 
     def test_transport_security_default_when_not_specified(self):
-        """Test transport security defaults when not specified in config."""
+        """Transport security is None when not specified (disabled by default)."""
         config_data = {
             "servers": {"local": {"url": "http://localhost:18080", "default": True}},
             "mcp": {"transports": ["streamable-http"]},
@@ -284,12 +289,9 @@ class TestTransportSecurityConfig(unittest.TestCase):
             with patch.dict(os.environ, {"SHS_MCP_CONFIG": temp_file_path}):
                 config = Config()
 
-            # Transport security should have default values
-            ts = config.mcp.transport_security
-            self.assertIsNotNone(ts)
-            self.assertFalse(ts.enable_dns_rebinding_protection)
-            self.assertEqual(ts.allowed_hosts, [])
-            self.assertEqual(ts.allowed_origins, [])
+            # Not configured -> None; app.run() then leaves the MCP library
+            # defaults in place (DNS rebinding protection off).
+            self.assertIsNone(config.mcp.transport_security)
         finally:
             os.unlink(temp_file_path)
 

--- a/tests/unit/test_config_resolution.py
+++ b/tests/unit/test_config_resolution.py
@@ -1,0 +1,141 @@
+"""Tests for the config file resolution cascade.
+
+Precedence (highest to lowest):
+  1. --config flag / SHS_MCP_CONFIG env var (explicit)
+  2. ./config.yaml (current working directory)
+  3. ~/.config/spark-mcp/config.yaml (XDG config home)
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from spark_history_mcp.config.config import (
+    Config,
+    resolve_config_path,
+    user_config_path,
+)
+
+
+def _write_yaml(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch, tmp_path):
+    """Isolate cwd, HOME, and XDG/SHS env vars for each test."""
+    monkeypatch.delenv("SHS_MCP_CONFIG", raising=False)
+    # Point HOME and XDG_CONFIG_HOME at a clean temp area so the real user
+    # config (if any) cannot leak into the test.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    # Run from a clean, empty working directory.
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    yield
+
+
+class TestUserConfigPath:
+    def test_uses_xdg_config_home_when_set(self, monkeypatch, tmp_path):
+        xdg = tmp_path / "custom-xdg"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        assert user_config_path() == str(xdg / "spark-mcp" / "config.yaml")
+
+    def test_falls_back_to_dot_config_when_xdg_unset(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        expected = str(Path.home() / ".config" / "spark-mcp" / "config.yaml")
+        assert user_config_path() == expected
+
+
+class TestResolveConfigPath:
+    def test_explicit_env_var_wins(self, monkeypatch, tmp_path):
+        # Even with a cwd config present, the explicit env var takes precedence.
+        _write_yaml(str(tmp_path / "cwd" / "config.yaml"), {"servers": {}})
+        explicit = tmp_path / "explicit.yaml"
+        explicit.write_text("servers: {}\n")
+        monkeypatch.setenv("SHS_MCP_CONFIG", str(explicit))
+
+        path, is_explicit = resolve_config_path()
+        assert path == str(explicit)
+        assert is_explicit is True
+
+    def test_explicit_missing_is_still_explicit(self, monkeypatch):
+        monkeypatch.setenv("SHS_MCP_CONFIG", "/nope/missing.yaml")
+        path, is_explicit = resolve_config_path()
+        assert path == "/nope/missing.yaml"
+        assert is_explicit is True
+
+    def test_cwd_used_when_no_env_var(self, tmp_path):
+        cwd_config = tmp_path / "cwd" / "config.yaml"
+        _write_yaml(str(cwd_config), {"servers": {}})
+        path, is_explicit = resolve_config_path()
+        assert path == "config.yaml"
+        assert is_explicit is False
+
+    def test_cwd_takes_precedence_over_user_config(self, monkeypatch, tmp_path):
+        xdg = tmp_path / "xdg"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        _write_yaml(str(xdg / "spark-mcp" / "config.yaml"), {"servers": {}})
+        _write_yaml(str(tmp_path / "cwd" / "config.yaml"), {"servers": {}})
+
+        path, is_explicit = resolve_config_path()
+        assert path == "config.yaml"
+        assert is_explicit is False
+
+    def test_user_config_used_when_no_cwd_config(self, monkeypatch, tmp_path):
+        xdg = tmp_path / "xdg"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        user_config = xdg / "spark-mcp" / "config.yaml"
+        _write_yaml(str(user_config), {"servers": {}})
+
+        path, is_explicit = resolve_config_path()
+        assert path == str(user_config)
+        assert is_explicit is False
+
+    def test_nothing_found_returns_none(self, monkeypatch, tmp_path):
+        xdg = tmp_path / "xdg"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        path, is_explicit = resolve_config_path()
+        assert path is None
+        assert is_explicit is False
+
+
+class TestConfigUsesResolution:
+    def test_loads_from_cwd_config(self, tmp_path):
+        _write_yaml(
+            str(tmp_path / "cwd" / "config.yaml"),
+            {"servers": {"from_cwd": {"url": "http://cwd:18080", "default": True}}},
+        )
+        config = Config()
+        assert "from_cwd" in config.servers
+        assert config.servers["from_cwd"].url == "http://cwd:18080"
+
+    def test_loads_from_user_config(self, monkeypatch, tmp_path):
+        xdg = tmp_path / "xdg"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        _write_yaml(
+            str(xdg / "spark-mcp" / "config.yaml"),
+            {"servers": {"from_user": {"url": "http://user:18080", "default": True}}},
+        )
+        config = Config()
+        assert "from_user" in config.servers
+        assert config.servers["from_user"].url == "http://user:18080"
+
+    def test_defaults_when_no_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        config = Config()
+        # Built-in default server.
+        assert "local" in config.servers
+        assert config.servers["local"].url == "http://localhost:18080"
+
+    def test_missing_explicit_raises(self, monkeypatch):
+        monkeypatch.setenv("SHS_MCP_CONFIG", "/nope/missing.yaml")
+        with pytest.raises(FileNotFoundError):
+            Config()


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This adds configuration resolution logic to allow for more flexible and intuitive ways of resolving configuration file locations.

  - Precedence: --config flag → SHS_MCP_CONFIG env var → ./config.yaml → ~/.config/spark-mcp/config.yaml (honoring $XDG_CONFIG_HOME) → built-in defaults.
  - Made the resolver fail fast when an explicitly specified config file is missing
  - Documented the config-file lookup order and a shared ~/.config/spark-mcp/config.yaml note in the README, and added copy-paste claude mcp add / kiro-cli mcp add quick-start commands