### PR TITLE
add configuration resolution logic for cli

### DIFF
--- a/skills/cli/cmd/prime.go
+++ b/skills/cli/cmd/prime.go
@@ -45,7 +45,7 @@ GLOBAL FLAGS
       --attempt STRING    Application attempt ID (for YARN apps with multiple attempts)
   -s, --server STRING     Server name from config file
   -o, --output FORMAT     txt (default) | json | yaml
-  -c, --config PATH       Config file (default: config.yaml)
+  -c, --config PATH       Config file (default: ./config.yaml, then ~/.config/spark-mcp/config.yaml)
       --timeout DURATION  HTTP timeout (default: 10s)
 
 LIST FLAGS (apps, jobs, stages, sql)
@@ -68,7 +68,7 @@ COMMAND DETAILS
 
 CONFIG FILE
   Generate a starter config: shs setup config > config.yaml
-  Default path: config.yaml (override with -c or SHS_CLI__CONFIG env var).
+  Lookup order: -c flag, then SHS_CLI__CONFIG, then ./config.yaml, then ~/.config/spark-mcp/config.yaml.
 
   servers:
     local:

--- a/skills/cli/cmd/root.go
+++ b/skills/cli/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,15 +22,10 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	defaultConfig := "config.yaml"
-	if v := os.Getenv("SHS_CLI__CONFIG"); v != "" {
-		defaultConfig = v
-	}
-
 	rootCmd.PersistentFlags().StringVarP(&appID, "app-id", "a", "", "Spark application ID (or SHS_APP_ID env var)")
 	rootCmd.PersistentFlags().StringVar(&attemptID, "attempt", "", "Application attempt ID (for YARN apps)")
 	rootCmd.PersistentFlags().StringVarP(&serverName, "server", "s", "", "Server name from config")
-	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", defaultConfig, "Path to config file")
+	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Path to config file (default: ./config.yaml, then ~/.config/spark-mcp/config.yaml; env: SHS_CLI__CONFIG)")
 	rootCmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "txt", "Output format (txt|json|yaml)")
 	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 10*time.Second, "HTTP request timeout")
 

--- a/skills/cli/config/config.go
+++ b/skills/cli/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/knadh/koanf/parsers/yaml"
@@ -16,14 +17,69 @@ import (
 const (
 	DefaultServerUrl = "http://localhost:18080"
 	EnvPREFIX        = "SHS_CLI__"
+	// EnvConfig points at an explicit config file.
+	EnvConfig = "SHS_CLI__CONFIG"
+	// DefaultConfigName is looked up in the cwd and the config home.
+	DefaultConfigName = "config.yaml"
+	// AppConfigDir is the per-user config subdir under the XDG config home,
+	// shared with the MCP server (~/.config/spark-mcp/config.yaml).
+	AppConfigDir = "spark-mcp"
 )
 
-func Load(path string) (*Config, error) {
+// userConfigPath returns $XDG_CONFIG_HOME (if set) or ~/.config, joined with
+// the app dir and config name. Returns "" if the home dir is unknown.
+func userConfigPath() string {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, AppConfigDir, DefaultConfigName)
+}
+
+// resolvePath picks the config file, highest precedence first: the --config
+// flag, then SHS_CLI__CONFIG, then ./config.yaml, then
+// ~/.config/spark-mcp/config.yaml. It returns (path, explicit); an explicit
+// path is returned without an existence check so a missing file fails fast,
+// and path is "" when nothing is found (fall back to defaults).
+func resolvePath(flagPath string) (path string, explicit bool) {
+	if flagPath != "" {
+		return flagPath, true
+	}
+	if v := os.Getenv(EnvConfig); v != "" {
+		return v, true
+	}
+	if _, err := os.Stat(DefaultConfigName); err == nil {
+		return DefaultConfigName, false
+	}
+	if userPath := userConfigPath(); userPath != "" {
+		if _, err := os.Stat(userPath); err == nil {
+			return userPath, false
+		}
+	}
+	return "", false
+}
+
+func Load(flagPath string) (*Config, error) {
 	k := koanf.New(".")
 
-	err := k.Load(file.Provider(path), yaml.Parser())
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("could not load %s, %w", path, err)
+	path, explicit := resolvePath(flagPath)
+	if path != "" {
+		err := k.Load(file.Provider(path), yaml.Parser())
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				// Explicit but missing -> fatal; discovered -> use defaults.
+				if explicit {
+					return nil, fmt.Errorf(
+						"config file not found: %s (set via --config or %s)", path, EnvConfig)
+				}
+			} else {
+				return nil, fmt.Errorf("could not load %s, %w", path, err)
+			}
+		}
 	}
 
 	// SHS_CLI__SERVERS__LOCAL__URL -> servers.local.url

--- a/skills/cli/config/config_test.go
+++ b/skills/cli/config/config_test.go
@@ -104,3 +104,160 @@ func TestLoad_EmptyServers(t *testing.T) {
 		t.Errorf("expected 1 servers, got %d", len(cfg.Servers))
 	}
 }
+
+// --- config path resolution cascade ---
+
+// isolateConfigEnv clears config-related env vars and points HOME/XDG at a
+// clean temp area, then switches to an empty working directory.
+func isolateConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvConfig, "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+}
+
+func TestResolve_ExplicitEnvWins(t *testing.T) {
+	isolateConfigEnv(t)
+	if err := os.WriteFile(DefaultConfigName, []byte("servers:\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	explicit := filepath.Join(t.TempDir(), "explicit.yaml")
+	if err := os.WriteFile(explicit, []byte("servers:\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvConfig, explicit)
+
+	path, exp := resolvePath("")
+	if path != explicit || !exp {
+		t.Fatalf("expected explicit env path, got (%q, %v)", path, exp)
+	}
+}
+
+func TestResolve_FlagWinsOverEnv(t *testing.T) {
+	isolateConfigEnv(t)
+	t.Setenv(EnvConfig, "/from/env.yaml")
+	path, exp := resolvePath("/from/flag.yaml")
+	if path != "/from/flag.yaml" || !exp {
+		t.Fatalf("expected flag path, got (%q, %v)", path, exp)
+	}
+}
+
+func TestResolve_CwdBeforeUserConfig(t *testing.T) {
+	isolateConfigEnv(t)
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	userDir := filepath.Join(xdg, AppConfigDir)
+	if err := os.MkdirAll(userDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, DefaultConfigName), []byte("servers:\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(DefaultConfigName, []byte("servers:\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	path, exp := resolvePath("")
+	if path != DefaultConfigName || exp {
+		t.Fatalf("expected cwd config (non-explicit), got (%q, %v)", path, exp)
+	}
+}
+
+func TestResolve_UserConfigWhenNoCwd(t *testing.T) {
+	isolateConfigEnv(t)
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	userDir := filepath.Join(xdg, AppConfigDir)
+	if err := os.MkdirAll(userDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(userDir, DefaultConfigName)
+	if err := os.WriteFile(want, []byte("servers:\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	path, exp := resolvePath("")
+	if path != want || exp {
+		t.Fatalf("expected user config (non-explicit), got (%q, %v)", path, exp)
+	}
+}
+
+func TestResolve_NothingFound(t *testing.T) {
+	isolateConfigEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	path, exp := resolvePath("")
+	if path != "" || exp {
+		t.Fatalf("expected no path, got (%q, %v)", path, exp)
+	}
+}
+
+func TestLoad_ExplicitMissingFailsFast(t *testing.T) {
+	isolateConfigEnv(t)
+	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err == nil {
+		t.Fatal("expected error for explicit missing config file")
+	}
+}
+
+func TestLoad_DefaultsWhenNoFile(t *testing.T) {
+	isolateConfigEnv(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Servers) != 1 {
+		t.Fatalf("expected 1 default server, got %d", len(cfg.Servers))
+	}
+	if cfg.Servers["local"].URL != DefaultServerUrl {
+		t.Errorf("expected default local url, got %s", cfg.Servers["local"].URL)
+	}
+}
+
+func TestLoad_DiscoversCwdConfig(t *testing.T) {
+	isolateConfigEnv(t)
+	if err := os.WriteFile(DefaultConfigName,
+		[]byte("servers:\n  fromcwd:\n    url: http://cwd:18080\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := cfg.Servers["fromcwd"]; !ok {
+		t.Fatalf("expected server discovered from cwd config, got %+v", cfg.Servers)
+	}
+}
+
+// TestLoad_IgnoresUnknownMCPFields documents forward-compatibility: a config
+// shared with the MCP server may carry fields the CLI does not model; they
+// must be ignored rather than cause an error.
+func TestLoad_IgnoresUnknownMCPFields(t *testing.T) {
+	isolateConfigEnv(t)
+	p := writeTestConfig(t, `
+servers:
+  prod:
+    default: true
+    url: "https://spark.example.com"
+    verify_ssl: true
+    use_proxy: true
+    timeout: 45
+    include_plan_description: true
+    auth:
+      token: tok
+mcp:
+  transports:
+    - streamable-http
+  port: "18888"
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("expected unknown MCP fields to be ignored, got error: %v", err)
+	}
+	prod := cfg.Servers["prod"]
+	if prod.URL != "https://spark.example.com" || !prod.VerifySSL || !prod.Default {
+		t.Errorf("unexpected prod server: %+v", prod)
+	}
+	if prod.Auth == nil || prod.Auth.Token != "tok" {
+		t.Errorf("expected auth.token preserved, got %+v", prod.Auth)
+	}
+}


### PR DESCRIPTION
This adds configuration resolution logic to allow for more flexible and intuitive ways of resolving configuration file locations.

  - Precedence: --config flag → SHS_MCP_CONFIG env var → ./config.yaml → ~/.config/spark-mcp/config.yaml (honoring $XDG_CONFIG_HOME) → built-in defaults.