### PR TITLE
Add missing CLI capabilities to MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Agents can target a specific server per query:
 | **Strands Agents** | streamable-http | [Setup →](examples/integrations/strands-agents/) |
 | **Local / Inspector** | streamable-http | [Setup →](TESTING.md) |
 
-### Available Tools (17)
+### Available Tools (18)
 
 <details>
 <summary>Available Tools</summary>
@@ -279,6 +279,7 @@ Agents can target a specific server per query:
 | `list_executors` | List executors with executor-id filtering and sorting (failed-tasks/duration/gc/id) |
 | `get_executor_summary` | Aggregate metrics across all executors |
 | `get_resource_usage_timeline` | Chronological executor add/remove with resource totals |
+| `get_executor_thread_dump` | JVM thread dump for a driver/executor, with state/name/blocked filters (running apps only) |
 
 #### Configuration & Environment
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Agents can target a specific server per query:
 | **Strands Agents** | streamable-http | [Setup →](examples/integrations/strands-agents/) |
 | **Local / Inspector** | streamable-http | [Setup →](TESTING.md) |
 
-### Available Tools (18)
+### Available Tools (19)
 
 <details>
 <summary>Available Tools</summary>
@@ -272,6 +272,7 @@ Agents can target a specific server per query:
 |------|-------------|
 | `list_stages` | List stages with status filtering and sorting (e.g. slowest by duration) |
 | `get_stage` | Stage detail with attempt and task metric distributions |
+| `list_stage_task_failures` | Failed tasks of a stage with their error messages (exception/stack trace) |
 
 #### Executor & Resource Analysis
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Agents can target a specific server per query:
 | **Strands Agents** | streamable-http | [Setup →](examples/integrations/strands-agents/) |
 | **Local / Inspector** | streamable-http | [Setup →](TESTING.md) |
 
-### Available Tools (16)
+### Available Tools (17)
 
 <details>
 <summary>Available Tools</summary>
@@ -283,7 +283,7 @@ Agents can target a specific server per query:
 #### Configuration & Environment
 | Tool | Description |
 |------|-------------|
-| `get_environment` | Spark config, JVM info, system properties, classpath |
+| `get_environment` | Spark config, JVM info, system properties, classpath; optional `section` filter to return a single part |
 
 #### SQL & Query Analysis
 | Tool | Description |
@@ -302,6 +302,7 @@ Agents can target a specific server per query:
 |------|-------------|
 | `compare_job_environments` | Diff Spark configs between two applications |
 | `compare_job_performance` | Diff performance metrics between two applications |
+| `compare_stages` | Compare two stages (optionally across applications): stage metrics and per-task p25/p50/p75/max quantiles |
 
 #### AWS Spark Troubleshooting (opt-in)
 | Tool | Description |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -83,19 +83,16 @@ tasks:
     desc: Run end-to-end tests against the Spark History Server e2e corpus
     cmds:
       - echo "🧪 Starting end-to-end tests..."
-      - echo "Backing up original config..."
-      - cp config.yaml config.yaml.backup
-      - defer: cp config.yaml.backup config.yaml && rm config.yaml.backup
       - defer:
           task: stop-all
       - defer:
           task: cli:stop-shs
-      - echo "Setting up e2e configuration..."
-      - cp tests/config-e2e.yaml config.yaml
       - echo "Starting Spark History Server..."
       - task: cli:start-shs
-      - echo "Starting MCP server..."
+      - echo "Starting MCP server (config tests/config-e2e.yaml)..."
       - task: start-mcp-bg
+        vars:
+          CONFIG: tests/config-e2e.yaml
       - |
         echo "Running e2e tests..."
         uv run pytest tests/e2e.py -v
@@ -181,7 +178,7 @@ tasks:
     cmds:
       - |
         echo "Starting MCP server in background..."
-        bash -c 'nohup uv run -m spark_history_mcp.core.main > mcp-server.log 2>&1 &'
+        {{if .CONFIG}}export SHS_MCP_CONFIG="{{.CONFIG}}"; {{end}}bash -c 'nohup uv run -m spark_history_mcp.core.main > mcp-server.log 2>&1 &'
 
       - task: wait-for-mcp
     status:

--- a/src/spark_history_mcp/api/spark_client.py
+++ b/src/spark_history_mcp/api/spark_client.py
@@ -37,6 +37,7 @@ from spark_history_mcp.api_client.models.executor import Executor
 from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.sql_execution import SQLExecution
 from spark_history_mcp.api_client.models.stage_data import StageData
+from spark_history_mcp.api_client.models.task import Task
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
 from spark_history_mcp.api_client.models.thread_stack_trace import ThreadStackTrace
 from spark_history_mcp.config.config import ServerConfig
@@ -335,6 +336,31 @@ class SparkRestClient:
             stage_id,
             attempt_id,
             quantiles=quantiles,
+        )
+
+    @_resilient_call
+    def list_stage_tasks(
+        self,
+        app_id: str,
+        stage_id: int,
+        attempt_id: int,
+        status: Optional[str] = None,
+        sort_by: Optional[str] = None,
+        offset: Optional[int] = None,
+        length: Optional[int] = None,
+        app_attempt_id: Optional[str] = None,
+    ) -> List[Task]:
+        """List tasks for a specific stage attempt, optionally filtered by status."""
+        app_path = self._app_path(app_id, app_attempt_id)
+        return self._invoke(
+            self._api.list_tasks,
+            app_path,
+            stage_id,
+            attempt_id,
+            status=status,
+            sort_by=sort_by,
+            offset=offset,
+            length=length,
         )
 
     # ------------------------------------------------------------------

--- a/src/spark_history_mcp/api/spark_client.py
+++ b/src/spark_history_mcp/api/spark_client.py
@@ -38,6 +38,7 @@ from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.sql_execution import SQLExecution
 from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
+from spark_history_mcp.api_client.models.thread_stack_trace import ThreadStackTrace
 from spark_history_mcp.config.config import ServerConfig
 
 _DEFAULT_QUANTILES = "0.05, 0.25, 0.5, 0.75, 0.95"
@@ -364,6 +365,22 @@ class SparkRestClient:
         app_path = self._app_path(app_id, app_attempt_id)
         executors = self._invoke(self._api.list_all_executors, app_path)
         return self._paginate(executors, offset, length)
+
+    @_resilient_call
+    def get_executor_thread_dump(
+        self,
+        app_id: str,
+        executor_id: str,
+        app_attempt_id: Optional[str] = None,
+    ) -> List[ThreadStackTrace]:
+        """Get the JVM thread dump for a driver or executor.
+
+        Use ``"driver"`` for the driver. The application must be running;
+        completed applications return 404 because the History Server does not
+        persist thread dumps.
+        """
+        app_path = self._app_path(app_id, app_attempt_id)
+        return self._invoke(self._api.get_executor_threads, app_path, executor_id)
 
     # ------------------------------------------------------------------
     # Environment

--- a/src/spark_history_mcp/models/mcp_types.py
+++ b/src/spark_history_mcp/models/mcp_types.py
@@ -213,3 +213,20 @@ class StageComparison(BaseModel):
     b: StageCompareSide
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class FailedTask(BaseModel):
+    """A single failed task with its error message.
+
+    Curated subset of the raw task payload focused on failure investigation;
+    the heavy per-task metrics are intentionally omitted.
+    """
+
+    task_id: Optional[int] = Field(None, alias="taskId")
+    attempt: Optional[int] = None
+    executor_id: Optional[str] = Field(None, alias="executorId")
+    host: Optional[str] = None
+    status: Optional[str] = None
+    error_message: Optional[str] = Field(None, alias="errorMessage")
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/src/spark_history_mcp/models/mcp_types.py
+++ b/src/spark_history_mcp/models/mcp_types.py
@@ -155,3 +155,61 @@ class SqlExecutionComparison(BaseModel):
     plan_comparison: Optional[SqlPlanComparison] = Field(None, alias="planComparison")
 
     model_config = ConfigDict(populate_by_name=True)
+
+
+class StageTaskQuantiles(BaseModel):
+    """Per-task metric distributions for a stage at the requested quantiles.
+
+    Each metric is a list aligned with ``quantiles`` (e.g. ``[p25, p50, p75,
+    max]``). Time metrics are milliseconds; byte metrics are bytes.
+    """
+
+    quantiles: List[float] = Field(default_factory=list)
+    duration: Optional[List[float]] = None
+    gc_time: Optional[List[float]] = Field(None, alias="gcTime")
+    scheduler_delay: Optional[List[float]] = Field(None, alias="schedulerDelay")
+    peak_execution_memory: Optional[List[float]] = Field(
+        None, alias="peakExecutionMemory"
+    )
+    input_bytes: Optional[List[float]] = Field(None, alias="inputBytes")
+    output_bytes: Optional[List[float]] = Field(None, alias="outputBytes")
+    shuffle_read_bytes: Optional[List[float]] = Field(None, alias="shuffleReadBytes")
+    shuffle_write_bytes: Optional[List[float]] = Field(None, alias="shuffleWriteBytes")
+    disk_bytes_spilled: Optional[List[float]] = Field(None, alias="diskBytesSpilled")
+    memory_bytes_spilled: Optional[List[float]] = Field(
+        None, alias="memoryBytesSpilled"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class StageCompareSide(BaseModel):
+    """One side of a stage comparison: stage-level metrics and task quantiles."""
+
+    app: str
+    stage_id: Optional[int] = Field(None, alias="stageId")
+    attempt_id: Optional[int] = Field(None, alias="attemptId")
+    status: Optional[str] = None
+    description: Optional[str] = None
+    duration: int = 0  # milliseconds (wall time, submission -> completion)
+    tasks: int = 0
+    failed_tasks: int = Field(0, alias="failedTasks")
+    input_bytes: int = Field(0, alias="inputBytes")
+    output_bytes: int = Field(0, alias="outputBytes")
+    shuffle_read_bytes: int = Field(0, alias="shuffleReadBytes")
+    shuffle_write_bytes: int = Field(0, alias="shuffleWriteBytes")
+    disk_bytes_spilled: int = Field(0, alias="diskBytesSpilled")
+    memory_bytes_spilled: int = Field(0, alias="memoryBytesSpilled")
+    jvm_gc_time: int = Field(0, alias="jvmGcTime")  # milliseconds
+    task_quantiles: Optional[StageTaskQuantiles] = Field(None, alias="taskQuantiles")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class StageComparison(BaseModel):
+    """Metrics and task-quantile diff between two stages."""
+
+    a: StageCompareSide
+    b: StageCompareSide
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
 from spark_history_mcp.api_client.models.application import Application
+from spark_history_mcp.api_client.models.environment import Environment
 from spark_history_mcp.api_client.models.executor import Executor
 from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.sql_execution import SQLExecution
@@ -584,9 +585,51 @@ def get_stage(
     return stage_data
 
 
+# Environment sections that can be requested individually via ``section``.
+_ENVIRONMENT_SECTION_FIELDS = (
+    "runtime",
+    "spark_properties",
+    "system_properties",
+    "hadoop_properties",
+    "metrics_properties",
+    "classpath_entries",
+)
+
+
+def _resolve_environment_section(section: str) -> str:
+    """Resolve a requested ``section`` to a canonical environment field name.
+
+    Accepts the field names in ``_ENVIRONMENT_SECTION_FIELDS``, compared
+    case-insensitively. Raises ``ValueError`` for anything else.
+    """
+    keep_field = section.strip().lower()
+    if keep_field not in _ENVIRONMENT_SECTION_FIELDS:
+        valid = ", ".join(repr(s) for s in _ENVIRONMENT_SECTION_FIELDS)
+        raise ValueError(f"invalid section {section!r}; expected one of {valid}")
+    return keep_field
+
+
+def _filter_environment_section(env: Environment, section: str) -> Environment:
+    """Return a copy of ``env`` with only the requested section populated.
+
+    Fields for the other sections — and ``resource_profiles`` — are cleared so
+    the response carries only the requested data.
+    """
+    keep_field = _resolve_environment_section(section)
+    filtered = env.model_copy(deep=True)
+    for env_field in _ENVIRONMENT_SECTION_FIELDS:
+        if env_field != keep_field:
+            setattr(filtered, env_field, None)
+    filtered.resource_profiles = None
+    return filtered
+
+
 @mcp.tool()
 def get_environment(
-    app_id: str, server: Optional[str] = None, app_attempt_id: Optional[str] = None
+    app_id: str,
+    server: Optional[str] = None,
+    app_attempt_id: Optional[str] = None,
+    section: Optional[str] = None,
 ):
     """
     Get the comprehensive Spark runtime configuration for a Spark application.
@@ -598,14 +641,24 @@ def get_environment(
         app_id: The Spark application ID
         server: Optional server name to use (uses default if not specified)
         app_attempt_id: Optional YARN application attempt ID (latest if omitted)
+        section: Optional section filter to return only one part of the
+            environment. One of "runtime", "spark_properties",
+            "system_properties", "hadoop_properties", "metrics_properties", or
+            "classpath_entries". When omitted, all sections are returned.
 
     Returns:
-        ApplicationEnvironmentInfo object containing environment details
+        ApplicationEnvironmentInfo object containing environment details. When
+        ``section`` is given, only that section is populated.
     """
     ctx = mcp.get_context()
     client = get_client_or_default(ctx, server, app_id)
 
-    return client.get_environment(app_id=app_id, app_attempt_id=app_attempt_id)
+    env = client.get_environment(app_id=app_id, app_attempt_id=app_attempt_id)
+
+    if section is not None:
+        env = _filter_environment_section(env, section)
+
+    return env
 
 
 @mcp.tool()

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -20,7 +20,10 @@ from spark_history_mcp.models.mcp_types import (
     SqlNodeTypeDiff,
     SqlPlanComparison,
     SqlStageSummary,
+    StageCompareSide,
+    StageComparison,
     StageMetricsAggregation,
+    StageTaskQuantiles,
 )
 
 from ..utils.utils import parallel_execute
@@ -1418,6 +1421,121 @@ def compare_sql_executions(
         )
 
     return comparison
+
+
+# Quantile points fetched for stage task-metric distributions: p25/p50/p75/max.
+_STAGE_COMPARE_QUANTILES = "0.25,0.5,0.75,1.0"
+
+
+def _build_stage_task_quantiles(summary) -> Optional[StageTaskQuantiles]:
+    """Map a ``TaskMetricsSummary`` into the curated stage quantiles model."""
+    if summary is None:
+        return None
+
+    def nested(obj, attr):
+        return getattr(obj, attr) if obj is not None else None
+
+    return StageTaskQuantiles(
+        quantiles=summary.quantiles or [],
+        duration=summary.duration,
+        gc_time=summary.jvm_gc_time,
+        scheduler_delay=summary.scheduler_delay,
+        peak_execution_memory=summary.peak_execution_memory,
+        input_bytes=nested(summary.input_metrics, "bytes_read"),
+        output_bytes=nested(summary.output_metrics, "bytes_written"),
+        shuffle_read_bytes=nested(summary.shuffle_read_metrics, "read_bytes"),
+        shuffle_write_bytes=nested(summary.shuffle_write_metrics, "write_bytes"),
+        disk_bytes_spilled=summary.disk_bytes_spilled,
+        memory_bytes_spilled=summary.memory_bytes_spilled,
+    )
+
+
+def _collect_stage_side(client, app_id: str, stage_id: int) -> StageCompareSide:
+    """Build one side of a stage comparison from the latest stage attempt."""
+    attempts = client.list_stage_attempts(
+        app_id=app_id,
+        stage_id=stage_id,
+        details=False,
+        with_summaries=False,
+    )
+    if not attempts:
+        raise ValueError(
+            f"No stage found with ID {stage_id} in application {app_id} "
+            "(it may have been skipped by AQE)"
+        )
+
+    stage = max(attempts, key=lambda s: s.attempt_id or 0)
+    attempt_id = stage.attempt_id or 0
+
+    # Task-metric quantiles are best-effort; a missing summary just omits them.
+    try:
+        summary = client.get_stage_task_summary(
+            app_id=app_id,
+            stage_id=stage_id,
+            attempt_id=attempt_id,
+            quantiles=_STAGE_COMPARE_QUANTILES,
+        )
+    except Exception:
+        summary = None
+
+    return StageCompareSide(
+        app=app_id,
+        stage_id=stage.stage_id,
+        attempt_id=attempt_id,
+        status=stage.status,
+        description=stage.description or stage.name,
+        duration=_duration_ms(stage.submission_time, stage.completion_time),
+        tasks=stage.num_tasks or 0,
+        failed_tasks=stage.num_failed_tasks or 0,
+        input_bytes=stage.input_bytes or 0,
+        output_bytes=stage.output_bytes or 0,
+        shuffle_read_bytes=stage.shuffle_read_bytes or 0,
+        shuffle_write_bytes=stage.shuffle_write_bytes or 0,
+        disk_bytes_spilled=stage.disk_bytes_spilled or 0,
+        memory_bytes_spilled=stage.memory_bytes_spilled or 0,
+        jvm_gc_time=stage.jvm_gc_time or 0,
+        task_quantiles=_build_stage_task_quantiles(summary),
+    )
+
+
+@mcp.tool()
+def compare_stages(
+    app_id1: str,
+    stage_id1: int,
+    app_id2: str,
+    stage_id2: int,
+    server: Optional[str] = None,
+) -> StageComparison:
+    """
+    Compare two stages side by side, optionally across applications.
+
+    For each stage the latest attempt is used. Returns stage-level metrics
+    (duration, task counts, input/output, shuffle read/write, disk/memory spill,
+    GC time) plus per-task metric distributions at the p25/p50/p75/max quantiles
+    (duration, GC time, scheduler delay, peak execution memory, input, output,
+    shuffle read/write, disk spill, memory spill).
+
+    The two stages may belong to different applications. Deltas are not
+    precomputed; compare the ``a`` and ``b`` sides directly.
+
+    Args:
+        app_id1: Application ID for the first stage
+        stage_id1: Stage ID within the first application
+        app_id2: Application ID for the second stage
+        stage_id2: Stage ID within the second application
+        server: Optional server name to use (uses default if not specified)
+
+    Returns:
+        StageComparison with an ``a`` and ``b`` side
+    """
+    ctx = mcp.get_context()
+    client1 = get_client_or_default(ctx, server, app_id1)
+    client2 = get_client_or_default(ctx, server, app_id2)
+
+    return StageComparison(
+        a=_collect_stage_side(client1, app_id1, stage_id1),
+        b=_collect_stage_side(client2, app_id2, stage_id2),
+    )
 
 
 @mcp.tool()

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -11,6 +11,7 @@ from spark_history_mcp.api_client.models.sql_execution import SQLExecution
 from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.core.app import mcp
 from spark_history_mcp.models.mcp_types import (
+    FailedTask,
     SqlCompareSide,
     SqlExecutionComparison,
     SqlExecutionDetail,
@@ -593,6 +594,87 @@ def get_stage(
         stage_data.task_metrics_distributions = task_summary
 
     return stage_data
+
+
+def _resolve_latest_stage_attempt_id(client, app_id: str, stage_id: int) -> int:
+    """Return the highest attempt id for a stage, or raise if the stage is absent."""
+    attempts = client.list_stage_attempts(
+        app_id=app_id,
+        stage_id=stage_id,
+        details=False,
+        with_summaries=False,
+    )
+    if not attempts:
+        raise ValueError(
+            f"No stage found with ID {stage_id} in application {app_id} "
+            "(it may have been skipped by AQE)"
+        )
+    return max(attempts, key=lambda s: s.attempt_id or 0).attempt_id or 0
+
+
+@mcp.tool()
+def list_stage_task_failures(
+    app_id: str,
+    stage_id: int,
+    server: Optional[str] = None,
+    stage_attempt_id: Optional[int] = None,
+    app_attempt_id: Optional[str] = None,
+) -> list:
+    """
+    Get the per-task error messages for a stage's failed tasks.
+
+    Use this to diagnose *why* a stage failed: it returns the actual exception
+    and stack trace recorded for each failed task, which the stage- and
+    job-level tools do not expose. A typical workflow is to find a failed or
+    slow stage with ``list_stages`` (or a failed job with ``list_jobs``), then
+    call this tool with that stage ID to read the underlying errors.
+
+    Only tasks with status ``FAILED`` are returned. By default the latest stage
+    attempt is inspected; pass ``stage_attempt_id`` to target a specific one.
+    The full, untruncated ``error_message`` is preserved so the complete stack
+    trace is available.
+
+    Args:
+        app_id: The Spark application ID.
+        stage_id: The stage ID to inspect.
+        server: Server name to query; uses the default server if omitted.
+        stage_attempt_id: Specific stage attempt to inspect; defaults to the
+            latest attempt.
+        app_attempt_id: YARN application attempt ID; uses the latest if omitted.
+
+    Returns:
+        A list of ``FailedTask`` objects, one per failed task, each with
+        ``task_id``, ``attempt``, ``executor_id``, ``host``, ``status``, and the
+        full ``error_message``. Empty if the stage attempt has no failed tasks.
+
+    Raises:
+        ValueError: If the stage does not exist (e.g. it was skipped by AQE).
+    """
+    ctx = mcp.get_context()
+    client = get_client_or_default(ctx, server, app_id)
+
+    if stage_attempt_id is None:
+        stage_attempt_id = _resolve_latest_stage_attempt_id(client, app_id, stage_id)
+
+    tasks = client.list_stage_tasks(
+        app_id=app_id,
+        stage_id=stage_id,
+        attempt_id=stage_attempt_id,
+        status="failed",
+        app_attempt_id=app_attempt_id,
+    )
+
+    return [
+        FailedTask(
+            task_id=t.task_id,
+            attempt=t.attempt,
+            executor_id=t.executor_id,
+            host=t.host,
+            status=t.status,
+            error_message=t.error_message,
+        )
+        for t in tasks
+    ]
 
 
 # Environment sections that can be requested individually via ``section``.

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -305,10 +305,17 @@ def get_client_or_default(
 
     clients = ctx.request_context.lifespan_context.clients
 
+    # An explicitly requested server must exist; do not silently fall back to
+    # the default, or callers can't tell which server actually answered.
     if server_name:
         client = clients.get(server_name)
-        if client:
-            return client
+        if client is None:
+            available = ", ".join(sorted(clients)) or "none"
+            raise ValueError(
+                f"No Spark server named '{server_name}' is configured "
+                f"(available servers: {available})."
+            )
+        return client
 
     if default_client:
         return default_client
@@ -754,6 +761,70 @@ def get_executor_summary(app_id: str, server: Optional[str] = None):
 
     executors = client.list_all_executors(app_id=app_id)
     return _calculate_executor_metrics(executors)
+
+
+def _filter_threads(threads, state, name, blocked_only):
+    """Filter thread-dump entries by state, name substring, and blocked status."""
+    if not state and not name and not blocked_only:
+        return list(threads)
+
+    name_low = name.lower() if name else None
+    result = []
+    for t in threads:
+        if state and (t.thread_state or "").upper() != state.upper():
+            continue
+        if name_low and name_low not in (t.thread_name or "").lower():
+            continue
+        if blocked_only and t.blocked_by_thread_id is None and t.lock_name is None:
+            continue
+        result.append(t)
+    return result
+
+
+@mcp.tool()
+def get_executor_thread_dump(
+    app_id: str,
+    executor_id: str,
+    server: Optional[str] = None,
+    state: Optional[str] = None,
+    name: Optional[str] = None,
+    blocked_only: bool = False,
+    app_attempt_id: Optional[str] = None,
+) -> list:
+    """
+    Get the JVM thread dump for a driver or executor.
+
+    Returns one entry per thread, each with its ID, name, state, daemon flag,
+    lock/blocking information, and full stack trace. Use ``executor_id="driver"``
+    for the driver.
+
+    The application must be **running**: completed applications return an error
+    because the Spark History Server does not persist thread dumps.
+
+    Args:
+        app_id: The Spark application ID
+        executor_id: Executor ID, or "driver" for the driver
+        server: Optional server name to use (uses default if not specified)
+        state: Optional thread-state filter (e.g. "RUNNABLE", "BLOCKED",
+            "WAITING", "TIMED_WAITING"); case-insensitive exact match
+        name: Optional case-insensitive substring match on the thread name
+        blocked_only: When True, return only threads blocked on a lock or
+            another thread
+        app_attempt_id: Optional YARN application attempt ID (latest if omitted)
+
+    Returns:
+        List of ThreadStackTrace objects, sorted by thread ID
+    """
+    ctx = mcp.get_context()
+    client = get_client_or_default(ctx, server, app_id)
+
+    threads = client.get_executor_thread_dump(
+        app_id=app_id, executor_id=executor_id, app_attempt_id=app_attempt_id
+    )
+
+    threads = _filter_threads(threads, state, name, blocked_only)
+    threads.sort(key=lambda t: t.thread_id if t.thread_id is not None else 0)
+    return threads
 
 
 @mcp.tool()

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -15,6 +15,7 @@ from spark_history_mcp.models.mcp_types import (
     SqlExecutionComparison,
     SqlExecutionDetail,
     SqlExecutionSummary,
+    StageComparison,
 )
 
 mcp_endpoint = "http://localhost:18888/mcp/"
@@ -593,5 +594,142 @@ async def test_get_environment_invalid_section():
     async with McpClient() as client:
         result = await client.call_tool(
             "get_environment", {"app_id": app1_id, "section": "invalid"}
+        )
+        assert result.isError
+
+
+# ---------------------------------------------------------------------------
+# compare_stages tool
+# ---------------------------------------------------------------------------
+# Stage 43 of app1 and stage 33 of app2 are the same query stage in each run
+# (see skills/cli/e2e/compare_stages.json for the golden values).
+app1_stage_id = 43
+app2_stage_id = 33
+
+
+@pytest.mark.asyncio
+async def test_compare_stages_across_apps():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "compare_stages",
+            {
+                "app_id1": app1_id,
+                "stage_id1": app1_stage_id,
+                "app_id2": app2_id,
+                "stage_id2": app2_stage_id,
+            },
+        )
+        assert not result.isError
+        cmp = _parse_one(result, StageComparison)
+
+        # Side A: app1 / stage 43.
+        a = cmp.a
+        assert a.app == app1_id
+        assert a.stage_id == app1_stage_id
+        assert a.attempt_id == 0
+        assert a.status == "COMPLETE"
+        assert a.duration == 2083
+        assert a.tasks == 3
+        assert a.failed_tasks == 0
+        assert a.input_bytes == 0
+        assert a.output_bytes == 57978751
+        assert a.shuffle_read_bytes == 60573008
+        assert a.shuffle_write_bytes == 0
+        assert a.disk_bytes_spilled == 70308061
+        assert a.memory_bytes_spilled == 83884800
+        assert a.jvm_gc_time == 96
+
+        # Side B: app2 / stage 33.
+        b = cmp.b
+        assert b.app == app2_id
+        assert b.stage_id == app2_stage_id
+        assert b.duration == 1407
+        assert b.tasks == 3
+        assert b.output_bytes == 57979805
+        assert b.shuffle_read_bytes == 60597318
+        assert b.disk_bytes_spilled == 0
+        assert b.memory_bytes_spilled == 0
+        assert b.jvm_gc_time == 84
+
+
+@pytest.mark.asyncio
+async def test_compare_stages_task_quantiles():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "compare_stages",
+            {
+                "app_id1": app1_id,
+                "stage_id1": app1_stage_id,
+                "app_id2": app2_id,
+                "stage_id2": app2_stage_id,
+            },
+        )
+        assert not result.isError
+        cmp = _parse_one(result, StageComparison)
+
+        qa = cmp.a.task_quantiles
+        assert qa is not None
+        assert qa.quantiles == [0.25, 0.5, 0.75, 1.0]
+        # Small integer-valued metrics are exact.
+        assert qa.duration == [1008, 1055, 1063, 1063]
+        assert qa.gc_time == [18, 36, 42, 42]
+        assert qa.scheduler_delay == [4, 6, 9, 9]
+        assert qa.peak_execution_memory == [6291392, 6291392, 12582784, 12582784]
+        assert qa.input_bytes == [0, 0, 0, 0]
+        assert qa.shuffle_write_bytes == [0, 0, 0, 0]
+        # Large byte-valued metrics are 32-bit floats in the API; the Python
+        # client widens them to 64-bit, so they differ by a few bytes from the
+        # Go CLI golden values. Tolerate that representation gap.
+        assert qa.output_bytes == pytest.approx(
+            [14679969, 14719199, 28579584, 28579584], abs=2
+        )
+        assert qa.shuffle_read_bytes == pytest.approx(
+            [15329098, 15377783, 29866128, 29866128], abs=2
+        )
+        assert qa.disk_bytes_spilled == pytest.approx(
+            [17384420, 17588552, 35335090, 35335090], abs=2
+        )
+        assert qa.memory_bytes_spilled == pytest.approx(
+            [20971200, 20971200, 41942400, 41942400], abs=2
+        )
+
+        # Side B has no spill, so its spill quantiles are all zero.
+        qb = cmp.b.task_quantiles
+        assert qb is not None
+        assert qb.disk_bytes_spilled == [0, 0, 0, 0]
+        assert qb.duration == [273, 1118, 1264, 1264]
+
+
+@pytest.mark.asyncio
+async def test_compare_stages_same_stage():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "compare_stages",
+            {
+                "app_id1": app1_id,
+                "stage_id1": app1_stage_id,
+                "app_id2": app1_id,
+                "stage_id2": app1_stage_id,
+            },
+        )
+        assert not result.isError
+        cmp = _parse_one(result, StageComparison)
+        # Comparing a stage with itself yields identical sides.
+        assert cmp.a.duration == cmp.b.duration
+        assert cmp.a.output_bytes == cmp.b.output_bytes
+        assert cmp.a.task_quantiles.duration == cmp.b.task_quantiles.duration
+
+
+@pytest.mark.asyncio
+async def test_compare_stages_not_found():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "compare_stages",
+            {
+                "app_id1": app1_id,
+                "stage_id1": 999999,
+                "app_id2": app2_id,
+                "stage_id2": app2_stage_id,
+            },
         )
         assert result.isError

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -12,6 +12,7 @@ from spark_history_mcp.api_client.models.executor import Executor
 from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.models.mcp_types import (
+    FailedTask,
     SqlExecutionComparison,
     SqlExecutionDetail,
     SqlExecutionSummary,
@@ -760,5 +761,57 @@ async def test_get_executor_thread_dump_completed_app_errors():
         result = await client.call_tool(
             "get_executor_thread_dump",
             {"app_id": app1_id, "executor_id": "driver"},
+        )
+        assert result.isError
+
+
+# ---------------------------------------------------------------------------
+# list_stage_task_failures tool
+# ---------------------------------------------------------------------------
+# Stage 5 of app1 is a FAILED stage with 7 failed tasks, each raising a Python
+# UDF exception (see skills/cli/e2e/fixtures.yaml: stage5_errors_app1).
+failed_stage_id = 5
+
+
+@pytest.mark.asyncio
+async def test_list_stage_task_failures():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "list_stage_task_failures",
+            {"app_id": app1_id, "stage_id": failed_stage_id},
+        )
+        assert not result.isError
+        tasks = _parse_list(result, FailedTask)
+        assert len(tasks) == 7
+        for t in tasks:
+            assert t.status == "FAILED"
+            assert t.executor_id == "driver"
+            assert t.error_message is not None
+            assert t.error_message.startswith(
+                "org.apache.spark.api.python.PythonException"
+            )
+        # Task IDs match the failed tasks recorded in the corpus.
+        assert sorted(t.task_id for t in tasks) == [13, 14, 15, 16, 17, 18, 19]
+
+
+@pytest.mark.asyncio
+async def test_list_stage_task_failures_none_for_successful_stage():
+    async with McpClient() as client:
+        # Stage 43 completed successfully, so it has no failed tasks.
+        result = await client.call_tool(
+            "list_stage_task_failures",
+            {"app_id": app1_id, "stage_id": app1_stage_id},
+        )
+        assert not result.isError
+        tasks = _parse_list(result, FailedTask)
+        assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_list_stage_task_failures_not_found():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "list_stage_task_failures",
+            {"app_id": app1_id, "stage_id": 999999},
         )
         assert result.isError

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -143,6 +143,17 @@ async def test_list_applications_by_id_via_secondary_server():
 
 
 @pytest.mark.asyncio
+async def test_unknown_server_errors():
+    async with McpClient() as client:
+        # An explicitly named server that does not exist must error, not
+        # silently fall back to the default server.
+        result = await client.call_tool(
+            "list_applications", {"app_id": app2_id, "server": "does-not-exist"}
+        )
+        assert result.isError
+
+
+@pytest.mark.asyncio
 async def test_list_applications_includes_attempts():
     """The unfiltered listing embeds each application's attempts."""
     async with McpClient() as client:
@@ -731,5 +742,23 @@ async def test_compare_stages_not_found():
                 "app_id2": app2_id,
                 "stage_id2": app2_stage_id,
             },
+        )
+        assert result.isError
+
+
+# ---------------------------------------------------------------------------
+# get_executor_thread_dump tool
+# ---------------------------------------------------------------------------
+# The e2e corpus is replayed from event logs, so every application is completed.
+# The History Server does not persist thread dumps, so the endpoint returns 404
+# and the tool surfaces an error. This confirms the tool is wired up end to end.
+
+
+@pytest.mark.asyncio
+async def test_get_executor_thread_dump_completed_app_errors():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_executor_thread_dump",
+            {"app_id": app1_id, "executor_id": "driver"},
         )
         assert result.isError

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -7,6 +7,7 @@ from mcp.client.streamable_http import streamable_http_client
 from mcp.types import TextContent
 
 from spark_history_mcp.api_client.models.application import Application
+from spark_history_mcp.api_client.models.environment import Environment
 from spark_history_mcp.api_client.models.executor import Executor
 from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.stage_data import StageData
@@ -543,3 +544,54 @@ async def test_compare_sql_executions_with_plan_diff():
             "WholeStageCodegen (8)": (1, 0),
             "WholeStageCodegen (9)": (1, 0),
         }
+
+
+# ---------------------------------------------------------------------------
+# Environment tool
+# ---------------------------------------------------------------------------
+# Every individually selectable section of the Environment model.
+ENV_SECTION_FIELDS = [
+    "runtime",
+    "spark_properties",
+    "system_properties",
+    "hadoop_properties",
+    "metrics_properties",
+    "classpath_entries",
+]
+
+
+@pytest.mark.asyncio
+async def test_get_environment_full():
+    async with McpClient() as client:
+        result = await client.call_tool("get_environment", {"app_id": app1_id})
+        assert not result.isError
+        env = _parse_one(result, Environment)
+        # The full environment exposes every section the corpus provides.
+        for field in ENV_SECTION_FIELDS:
+            assert getattr(env, field) is not None, field
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("section", ENV_SECTION_FIELDS)
+async def test_get_environment_section(section):
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_environment", {"app_id": app1_id, "section": section}
+        )
+        assert not result.isError
+        env = _parse_one(result, Environment)
+        # The requested section is populated and every other section is cleared.
+        assert getattr(env, section) is not None, section
+        for other in ENV_SECTION_FIELDS:
+            if other != section:
+                assert getattr(env, other) is None, other
+        assert env.resource_profiles is None
+
+
+@pytest.mark.asyncio
+async def test_get_environment_invalid_section():
+    async with McpClient() as client:
+        result = await client.call_tool(
+            "get_environment", {"app_id": app1_id, "section": "invalid"}
+        )
+        assert result.isError

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -10,14 +10,17 @@ from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.sql_execution import SQLExecution
 from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
+from spark_history_mcp.api_client.models.thread_stack_trace import ThreadStackTrace
 from spark_history_mcp.tools.tools import (
     _build_stage_task_quantiles,
     _calculate_executor_metrics,
     _filter_environment_section,
+    _filter_threads,
     compare_sql_executions,
     compare_stages,
     get_client_or_default,
     get_environment,
+    get_executor_thread_dump,
     get_sql_execution,
     get_stage,
     list_applications,
@@ -65,25 +68,24 @@ class TestTools(unittest.TestCase):
         # Should return the default client
         self.assertEqual(client, self.mock_client1)
 
-    def test_get_client_not_found_with_default(self):
-        """Test behavior when requested client is not found but default exists"""
+    def test_get_client_not_found_errors(self):
+        """A requested server that does not exist raises, even with a default."""
         self.mock_lifespan_context.default_client = self.mock_client1
 
-        # Get non-existent client
-        client = get_client_or_default(self.mock_ctx, "non_existent_server")
+        with self.assertRaises(ValueError) as context:
+            get_client_or_default(self.mock_ctx, "non_existent_server")
 
-        # Should fall back to default client
-        self.assertEqual(client, self.mock_client1)
+        self.assertIn("non_existent_server", str(context.exception))
 
     def test_no_client_found(self):
-        """Test error when no client is found and no default exists"""
+        """An unknown server with no default still raises (now naming the server)."""
         self.mock_lifespan_context.default_client = None
 
         # Try to get non-existent client with no default
         with self.assertRaises(ValueError) as context:
             get_client_or_default(self.mock_ctx, "non_existent_server")
 
-        self.assertIn("No Spark client found", str(context.exception))
+        self.assertIn("non_existent_server", str(context.exception))
 
     def test_no_default_client(self):
         """Test error when no name is provided and no default exists"""
@@ -1445,3 +1447,58 @@ class TestTools(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             compare_stages("app-1", 999, "app-2", 1)
+
+    # Tests for get_executor_thread_dump / _filter_threads
+    @staticmethod
+    def _sample_threads():
+        return [
+            ThreadStackTrace(threadId=1, threadName="main", threadState="RUNNABLE"),
+            ThreadStackTrace(
+                threadId=2,
+                threadName="dispatcher-event-loop-0",
+                threadState="WAITING",
+                blockedByThreadId=1,
+            ),
+            ThreadStackTrace(
+                threadId=3,
+                threadName="Executor task launch worker for task 42",
+                threadState="BLOCKED",
+                lockName="java.util.concurrent.locks.ReentrantLock",
+            ),
+            ThreadStackTrace(
+                threadId=4,
+                threadName="DispatcherWatcher",
+                threadState="TIMED_WAITING",
+            ),
+        ]
+
+    def test_filter_threads(self):
+        cases = [
+            ("no filter", None, None, False, [1, 2, 3, 4]),
+            ("state RUNNABLE", "RUNNABLE", None, False, [1]),
+            ("state lowercase matches", "blocked", None, False, [3]),
+            ("name substring case-insensitive", None, "DISPATCHER", False, [2, 4]),
+            ("blocked-only catches blocked_by", None, None, True, [2, 3]),
+            ("combine state + name", "WAITING", "dispatcher", False, [2]),
+            ("no match returns empty", None, "nonexistent", False, []),
+        ]
+        for label, state, name, blocked_only, want_ids in cases:
+            with self.subTest(label):
+                got = _filter_threads(self._sample_threads(), state, name, blocked_only)
+                self.assertEqual([t.thread_id for t in got], want_ids)
+
+    @patch("spark_history_mcp.tools.tools.mcp")
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_executor_thread_dump_sorts_by_id(self, mock_get_client, mock_mcp):
+        mock_client = MagicMock()
+        # Returned out of order; the tool sorts by thread ID.
+        mock_client.get_executor_thread_dump.return_value = list(
+            reversed(self._sample_threads())
+        )
+        mock_get_client.return_value = mock_client
+
+        threads = get_executor_thread_dump("app-1", "driver")
+        self.assertEqual([t.thread_id for t in threads], [1, 2, 3, 4])
+        mock_client.get_executor_thread_dump.assert_called_once_with(
+            app_id="app-1", executor_id="driver", app_attempt_id=None
+        )

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -11,9 +11,11 @@ from spark_history_mcp.api_client.models.sql_execution import SQLExecution
 from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
 from spark_history_mcp.tools.tools import (
+    _build_stage_task_quantiles,
     _calculate_executor_metrics,
     _filter_environment_section,
     compare_sql_executions,
+    compare_stages,
     get_client_or_default,
     get_environment,
     get_sql_execution,
@@ -1405,3 +1407,41 @@ class TestTools(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             get_environment("spark-app-123", section="bogus")
+
+    # Tests for compare_stages
+    def test_build_stage_task_quantiles_maps_nested_metrics(self):
+        """Nested input/output/shuffle metrics are flattened into the model."""
+        summary = TaskMetricsSummary.from_dict(
+            {
+                "quantiles": [0.25, 0.5, 0.75, 1.0],
+                "duration": [1, 2, 3, 4],
+                "jvmGcTime": [0, 1, 1, 2],
+                "schedulerDelay": [1, 1, 1, 1],
+                "inputMetrics": {"bytesRead": [10, 20, 30, 40]},
+                "outputMetrics": {"bytesWritten": [1, 2, 3, 4]},
+                "shuffleReadMetrics": {"readBytes": [5, 6, 7, 8]},
+                "shuffleWriteMetrics": {"writeBytes": [0, 0, 0, 0]},
+            }
+        )
+        q = _build_stage_task_quantiles(summary)
+        self.assertEqual(q.quantiles, [0.25, 0.5, 0.75, 1.0])
+        self.assertEqual(q.duration, [1, 2, 3, 4])
+        self.assertEqual(q.gc_time, [0, 1, 1, 2])
+        self.assertEqual(q.input_bytes, [10, 20, 30, 40])
+        self.assertEqual(q.output_bytes, [1, 2, 3, 4])
+        self.assertEqual(q.shuffle_read_bytes, [5, 6, 7, 8])
+        self.assertEqual(q.shuffle_write_bytes, [0, 0, 0, 0])
+
+    def test_build_stage_task_quantiles_none(self):
+        """A missing summary maps to None."""
+        self.assertIsNone(_build_stage_task_quantiles(None))
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_compare_stages_not_found(self, mock_get_client):
+        """A stage with no attempts raises ValueError."""
+        mock_client = MagicMock()
+        mock_client.list_stage_attempts.return_value = []
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(ValueError):
+            compare_stages("app-1", 999, "app-2", 1)

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from spark_history_mcp.api.spark_client import SparkRestClient
 from spark_history_mcp.api_client.models.application import Application
+from spark_history_mcp.api_client.models.environment import Environment
 from spark_history_mcp.api_client.models.executor import Executor
 from spark_history_mcp.api_client.models.job import Job
 from spark_history_mcp.api_client.models.sql_execution import SQLExecution
@@ -11,8 +12,10 @@ from spark_history_mcp.api_client.models.stage_data import StageData
 from spark_history_mcp.api_client.models.task_metrics_summary import TaskMetricsSummary
 from spark_history_mcp.tools.tools import (
     _calculate_executor_metrics,
+    _filter_environment_section,
     compare_sql_executions,
     get_client_or_default,
+    get_environment,
     get_sql_execution,
     get_stage,
     list_applications,
@@ -1362,3 +1365,43 @@ class TestTools(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             list_executors("spark-app-123", sort_by="bogus")
+
+    # Tests for get_environment section filtering
+    @staticmethod
+    def _environment():
+        return Environment.from_dict(
+            {
+                "runtime": {"javaVersion": "17", "scalaVersion": "2.12"},
+                "sparkProperties": [["spark.app.name", "demo"]],
+                "systemProperties": [["os.name", "Linux"]],
+                "hadoopProperties": [["fs.defaultFS", "file:///"]],
+                "metricsProperties": [["*.sink.csv.class", "x"]],
+                "classpathEntries": [["/opt/spark/jars/x.jar", "System Classpath"]],
+            }
+        )
+
+    def test_filter_environment_section_keeps_only_requested(self):
+        """Filtering keeps the requested section and clears the others."""
+        env = _filter_environment_section(self._environment(), "spark_properties")
+        self.assertTrue(env.spark_properties)
+        self.assertIsNone(env.runtime)
+        self.assertIsNone(env.system_properties)
+        self.assertIsNone(env.hadoop_properties)
+        self.assertIsNone(env.metrics_properties)
+        self.assertIsNone(env.classpath_entries)
+
+    def test_filter_environment_section_runtime(self):
+        """The runtime section maps to the runtime field."""
+        env = _filter_environment_section(self._environment(), "runtime")
+        self.assertIsNotNone(env.runtime)
+        self.assertIsNone(env.spark_properties)
+
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_get_environment_invalid_section(self, mock_get_client):
+        """An unknown section raises ValueError."""
+        mock_client = MagicMock()
+        mock_client.get_environment.return_value = self._environment()
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(ValueError):
+            get_environment("spark-app-123", section="bogus")

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -27,6 +27,7 @@ from spark_history_mcp.tools.tools import (
     list_executors,
     list_jobs,
     list_sql_executions,
+    list_stage_task_failures,
     list_stages,
 )
 
@@ -1502,3 +1503,55 @@ class TestTools(unittest.TestCase):
         mock_client.get_executor_thread_dump.assert_called_once_with(
             app_id="app-1", executor_id="driver", app_attempt_id=None
         )
+
+    # Tests for list_stage_task_failures
+    @patch("spark_history_mcp.tools.tools.mcp")
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_stage_task_failures(self, mock_get_client, mock_mcp):
+        from spark_history_mcp.api_client.models.task import Task
+
+        mock_client = MagicMock()
+        # Two stage attempts; the tool should use the latest (id 1).
+        attempt0 = MagicMock()
+        attempt0.attempt_id = 0
+        attempt1 = MagicMock()
+        attempt1.attempt_id = 1
+        mock_client.list_stage_attempts.return_value = [attempt0, attempt1]
+        mock_client.list_stage_tasks.return_value = [
+            Task(
+                taskId=7,
+                attempt=2,
+                executorId="driver",
+                host="h1",
+                status="FAILED",
+                errorMessage="org.apache.spark.SparkException: boom\n at ...",
+            )
+        ]
+        mock_get_client.return_value = mock_client
+
+        failures = list_stage_task_failures("app-1", 5)
+
+        self.assertEqual(len(failures), 1)
+        self.assertEqual(failures[0].task_id, 7)
+        self.assertEqual(failures[0].executor_id, "driver")
+        self.assertTrue(
+            failures[0].error_message.startswith("org.apache.spark.SparkException")
+        )
+        # Latest attempt resolved and a failed-status filter applied.
+        mock_client.list_stage_tasks.assert_called_once_with(
+            app_id="app-1",
+            stage_id=5,
+            attempt_id=1,
+            status="failed",
+            app_attempt_id=None,
+        )
+
+    @patch("spark_history_mcp.tools.tools.mcp")
+    @patch("spark_history_mcp.tools.tools.get_client_or_default")
+    def test_list_stage_task_failures_not_found(self, mock_get_client, mock_mcp):
+        mock_client = MagicMock()
+        mock_client.list_stage_attempts.return_value = []
+        mock_get_client.return_value = mock_client
+
+        with self.assertRaises(ValueError):
+            list_stage_task_failures("app-1", 999)


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

  - Added get_environment section parameter to return a single environment section (runtime, spark/system/hadoop/metrics properties, classpath).
  - Added compare_stages tool comparing two stages' metrics and per-task p25/p50/p75/max quantiles, across applications.
  - Added get_executor_thread_dump tool with state/name/blocked-only filters; surfaces 404 for completed apps.
  - Added list_stage_task_failures tool returning failed tasks' full error messages/stack traces, with refined agent-facing docstring.

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
# Example:
# task test
# npx @modelcontextprotocol/inspector uv run -m spark_history_mcp.core.main
```

## 🛠️ New Tools Added (if applicable)
<!-- For new MCP tools -->
- **Tool Name**: `new_tool_name`
- **Purpose**: What it does
- **Usage**: Example parameters

## 📸 Screenshots (if applicable)
<!-- For UI changes or new tools, include MCP Inspector screenshots -->

## ✅ Checklist
- [ ] 🔍 Code follows project style guidelines
- [ ] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.)
- [ ] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md (if significant change)

## 📚 Related Issues
<!-- Link any related issues -->
Fixes #(issue number)
Related to #(issue number)

## 🤔 Additional Context
<!-- Add any additional context, screenshots, or notes -->

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
