### PR TITLE
Update the env var deliminator. Deprecate transports field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,27 @@
 # Spark History Server MCP Configuration
+#
+# Nesting levels are separated by a DOUBLE underscore (__). This lets field
+# names and server names contain single underscores, e.g.
+# SHS_SERVERS__MY_SERVER__URL -> servers.my_server.url
 
 # MCP Server Settings
-SHS_MCP_PORT=18888 # Port for MCP server (default: 18888)
-SHS_MCP_DEBUG=true # Enable debug mode (default: false)
-SHS_MCP_ADDRESS=0.0.0.0 # Address for MCP server (default: localhost)
-SHS_MCP_TRANSPORT=streamable-http
+SHS_MCP__PORT=18888 # Port for MCP server (default: 18888)
+SHS_MCP__DEBUG=true # Enable debug mode (default: false)
+SHS_MCP__ADDRESS=0.0.0.0 # Address for MCP server (default: localhost)
+SHS_MCP__TRANSPORT=streamable-http
 
 # Transport Security Settings (DNS rebinding protection)
 # See: https://github.com/modelcontextprotocol/python-sdk/issues/1798
-# SHS_MCP_TRANSPORT_SECURITY_ENABLE_DNS_REBINDING_PROTECTION=true
-# SHS_MCP_TRANSPORT_SECURITY_ALLOWED_HOSTS=["localhost:*","127.0.0.1:*","your-gateway:*"]
-# SHS_MCP_TRANSPORT_SECURITY_ALLOWED_ORIGINS=["http://localhost:*","http://127.0.0.1:*"]
+# SHS_MCP__TRANSPORT_SECURITY__ENABLE_DNS_REBINDING_PROTECTION=true
+# SHS_MCP__TRANSPORT_SECURITY__ALLOWED_HOSTS=["localhost:*","127.0.0.1:*","your-gateway:*"]
+# SHS_MCP__TRANSPORT_SECURITY__ALLOWED_ORIGINS=["http://localhost:*","http://127.0.0.1:*"]
 
 # Spark History Server Settings
-# SHS_SERVERS_*_URL - URL for a specific server
-# SHS_SERVERS_*_AUTH_USERNAME - Username for a specific server
-# SHS_SERVERS_*_AUTH_PASSWORD - Password for a specific server
-# SHS_SERVERS_*_AUTH_TOKEN - Token for a specific server
-# SHS_SERVERS_*_VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
-# SHS_SERVERS_*_TIMEOUT - HTTP request timeout in seconds for a specific server (default: 30)
-# SHS_SERVERS_*_EMR_CLUSTER_ARN - EMR cluster ARN for a specific server
+# (replace * with the server name; the name itself may contain underscores)
+# SHS_SERVERS__*__URL - URL for a specific server
+# SHS_SERVERS__*__AUTH__USERNAME - Username for a specific server
+# SHS_SERVERS__*__AUTH__PASSWORD - Password for a specific server
+# SHS_SERVERS__*__AUTH__TOKEN - Token for a specific server
+# SHS_SERVERS__*__VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
+# SHS_SERVERS__*__TIMEOUT - HTTP request timeout in seconds for a specific server (default: 30)
+# SHS_SERVERS__*__EMR_CLUSTER_ARN - EMR cluster ARN for a specific server

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ The package is published to [PyPI](https://pypi.org/project/mcp-apache-spark-his
 
 Register the server with a single command. Both examples run it over **stdio** via `uvx`.
 With no config file present, the server defaults to a Spark History Server at `http://localhost:18080`;
-point it elsewhere with a [config file](#config-file-location) or `SHS_SERVERS_LOCAL_URL`.
+point it elsewhere with a [config file](#config-file-location) or `SHS_SERVERS__LOCAL__URL`.
 
 **Claude Code** (`claude mcp add`):
 
 ```bash
-claude mcp add --env SHS_MCP_TRANSPORT=stdio --env SHS_SERVERS_LOCAL_URL=http://localhost:18080\
+claude mcp add --env SHS_MCP__TRANSPORT=stdio --env SHS_SERVERS__LOCAL__URL=http://localhost:18080\
   --transport stdio spark-history \
   -- uvx --from mcp-apache-spark-history-server spark-mcp
 ```
@@ -112,7 +112,7 @@ claude mcp add --env SHS_MCP_TRANSPORT=stdio --env SHS_SERVERS_LOCAL_URL=http://
 ```bash
 kiro-cli mcp add --name spark-history --command uvx \
   --args --from --args mcp-apache-spark-history-server --args spark-mcp \
-  --env SHS_MCP_TRANSPORT=stdio --env SHS_SERVERS_LOCAL_URL=http://localhost:18080
+  --env SHS_MCP__TRANSPORT=stdio --env SHS_SERVERS__LOCAL__URL=http://localhost:18080
 ```
 
 Verify in either client with `claude mcp list` / `kiro-cli mcp list`, then ask the agent to *"list the available Spark applications."*
@@ -132,14 +132,14 @@ For example, to point at a remote Spark History Server with an explicit config f
 
 ```bash
 # Claude Code
-claude mcp add --env SHS_MCP_TRANSPORT=stdio --transport stdio spark-history \
+claude mcp add --env SHS_MCP__TRANSPORT=stdio --transport stdio spark-history \
   -- uvx --from mcp-apache-spark-history-server spark-mcp --config ~/.config/spark-mcp/config.yaml
 
 # Kiro CLI
 kiro-cli mcp add --name spark-history --command uvx \
   --args --from --args mcp-apache-spark-history-server --args spark-mcp \
   --args --config --args ~/.config/spark-mcp/config.yaml \
-  --env SHS_MCP_TRANSPORT=stdio
+  --env SHS_MCP__TRANSPORT=stdio
 ```
 
 ### Configure
@@ -156,8 +156,7 @@ servers:
       password: "pass"
     include_plan_description: false   # include SQL plans by default (default: false)
 mcp:
-  transports:
-    - streamable-http   # or: stdio
+  transport: "streamable-http"   # or: stdio
   port: "18888"
   debug: false
 ```
@@ -175,21 +174,24 @@ If none exist, the server starts with built-in defaults that can be overridden b
 
 > **Tip for MCP clients:** when the server is launched by an MCP client (Claude Desktop, Kiro, etc.), the working directory is not guaranteed, so a `./config.yaml` may not be found. Prefer `--config` / `SHS_MCP_CONFIG`, or place the file at `~/.config/spark-mcp/config.yaml`.
 
-Configurations can be overriden with environment variables.
+Configurations can be overriden with environment variables. Nesting levels are
+separated by a **double underscore** (`__`), so field names and server names may
+themselves contain single underscores (e.g. `SHS_SERVERS__MY_SERVER__URL` maps
+to `servers.my_server.url`).
 
 ```
-SHS_MCP_PORT          Port for MCP server (default: 18888)
-SHS_MCP_TRANSPORT     Transport mode: streamable-http or stdio
-SHS_MCP_DEBUG         Enable debug mode (default: false)
-SHS_MCP_ADDRESS       Bind address (default: localhost)
-SHS_SERVERS_*_URL     URL for a specific server
-SHS_SERVERS_*_AUTH_USERNAME
-SHS_SERVERS_*_AUTH_PASSWORD
-SHS_SERVERS_*_AUTH_TOKEN
-SHS_SERVERS_*_VERIFY_SSL
-SHS_SERVERS_*_TIMEOUT
-SHS_SERVERS_*_EMR_CLUSTER_ARN
-SHS_SERVERS_*_INCLUDE_PLAN_DESCRIPTION
+SHS_MCP__PORT          Port for MCP server (default: 18888)
+SHS_MCP__TRANSPORT     Transport mode: streamable-http or stdio
+SHS_MCP__DEBUG         Enable debug mode (default: false)
+SHS_MCP__ADDRESS       Bind address (default: localhost)
+SHS_SERVERS__*__URL     URL for a specific server
+SHS_SERVERS__*__AUTH__USERNAME
+SHS_SERVERS__*__AUTH__PASSWORD
+SHS_SERVERS__*__AUTH__TOKEN
+SHS_SERVERS__*__VERIFY_SSL
+SHS_SERVERS__*__TIMEOUT
+SHS_SERVERS__*__EMR_CLUSTER_ARN
+SHS_SERVERS__*__INCLUDE_PLAN_DESCRIPTION
 ```
 
 ### Multi-Server Setup

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,7 +29,7 @@ Update the `timeout` value in your MCP client configuration (e.g., `mcp.json`):
     "--frozen"
   ],
   "env": {
-    "SHS_MCP_TRANSPORT": "stdio"
+    "SHS_MCP__TRANSPORT": "stdio"
   },
   "disabled": false,
   "autoApprove": [],
@@ -58,8 +58,8 @@ Set the server timeout environment variable:
     "--frozen"
   ],
   "env": {
-    "SHS_MCP_TRANSPORT": "stdio",
-    "SHS_SERVERS_LOCAL_TIMEOUT": "500" <-- Set this value in seconds
+    "SHS_MCP__TRANSPORT": "stdio",
+    "SHS_SERVERS__LOCAL__TIMEOUT": "500" <-- Set this value in seconds
   },
   "disabled": false,
   "autoApprove": [],
@@ -67,7 +67,7 @@ Set the server timeout environment variable:
 }
 ```
 
-**Note:** SHS_SERVERS_<Replace with server name in config.yaml>_TIMEOUT
+**Note:** SHS_SERVERS__<Replace with server name in config.yaml>__TIMEOUT
 
 ### 3: JVM Heap Exhaustion
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,8 +5,8 @@ servers:
     url: "http://localhost:18080"
     # Optional authentication (can also use environment variables).
     # auth:
-    #   username: ${SHS_SERVERS_LOCAL_AUTH_USERNAME}
-    #   password: ${SHS_SERVERS_LOCAL_AUTH_PASSWORD}
+    #   username: ${SHS_SERVERS__LOCAL__AUTH__USERNAME}
+    #   password: ${SHS_SERVERS__LOCAL__AUTH__PASSWORD}
     #   token: ${SHS_SPARK_TOKEN}
 
   # Production server example
@@ -15,8 +15,8 @@ servers:
   #   verify_ssl: true
   #   auth:
       # Use environment variables for production
-      # username: ${SHS_SERVERS_PRODUCTION_AUTH_USERNAME}
-      # password: ${SHS_SERVERS_PRODUCTION_AUTH_PASSWORD}
+      # username: ${SHS_SERVERS__PRODUCTION__AUTH__USERNAME}
+      # password: ${SHS_SERVERS__PRODUCTION__AUTH__PASSWORD}
       # token: ${SHS_SPARK_TOKEN}
 
   # Staging server example
@@ -24,8 +24,8 @@ servers:
   #   url: "https://staging-spark-history.company.com:18080"
   #   verify_ssl: true
   #   auth:
-      # username: ${SHS_SERVERS_STAGING_AUTH_USERNAME}
-      # token: ${SHS_SERVERS_STAGING_AUTH_PASSWORD}
+      # username: ${SHS_SERVERS__STAGING__AUTH__USERNAME}
+      # token: ${SHS_SERVERS__STAGING__AUTH__PASSWORD}
 
   # AWS Glue Spark History Server example
   # glue_ec2:
@@ -36,8 +36,7 @@ servers:
 #    emr_cluster_arn: "<EMR Cluster ARN>"
 
 mcp:
-  transports:
-    - streamable-http # streamable-http or stdio. you can only specify one right now.
+  transport: streamable-http # streamable-http or stdio.
   port: "18888"
   debug: true
   address: localhost
@@ -66,16 +65,18 @@ mcp:
 
 
 # Available Environment Variables:
-# SHS_MCP_PORT - Port for MCP server (default: 18888)
-# SHS_MCP_DEBUG - Enable debug mode (default: false)
-# SHS_MCP_ADDRESS - Address for MCP server (default: localhost)
-# SHS_MCP_TRANSPORT - MCP transport mode (default: streamable-http)
-# SHS_MCP_TRANSPORT_SECURITY_ENABLE_DNS_REBINDING_PROTECTION - Enable DNS rebinding protection (true/false)
-# SHS_MCP_TRANSPORT_SECURITY_ALLOWED_HOSTS - JSON array of allowed hosts (e.g., '["localhost:*","127.0.0.1:*"]')
-# SHS_MCP_TRANSPORT_SECURITY_ALLOWED_ORIGINS - JSON array of allowed origins (e.g., '["http://localhost:*"]')
-# SHS_SERVERS_*_URL - URL for a specific server
-# SHS_SERVERS_*_AUTH_USERNAME - Username for a specific server
-# SHS_SERVERS_*_AUTH_PASSWORD - Password for a specific server
-# SHS_SERVERS_*_AUTH_TOKEN - Token for a specific server
-# SHS_SERVERS_*_VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
-# SHS_SERVERS_*_EMR_CLUSTER_ARN - EMR cluster ARN for a specific server
+# Nesting levels are separated by a DOUBLE underscore (__), so field names and
+# server names may themselves contain single underscores.
+# SHS_MCP__PORT - Port for MCP server (default: 18888)
+# SHS_MCP__DEBUG - Enable debug mode (default: false)
+# SHS_MCP__ADDRESS - Address for MCP server (default: localhost)
+# SHS_MCP__TRANSPORT - MCP transport mode (default: streamable-http)
+# SHS_MCP__TRANSPORT_SECURITY__ENABLE_DNS_REBINDING_PROTECTION - Enable DNS rebinding protection (true/false)
+# SHS_MCP__TRANSPORT_SECURITY__ALLOWED_HOSTS - JSON array of allowed hosts (e.g., '["localhost:*","127.0.0.1:*"]')
+# SHS_MCP__TRANSPORT_SECURITY__ALLOWED_ORIGINS - JSON array of allowed origins (e.g., '["http://localhost:*"]')
+# SHS_SERVERS__*__URL - URL for a specific server
+# SHS_SERVERS__*__AUTH__USERNAME - Username for a specific server
+# SHS_SERVERS__*__AUTH__PASSWORD - Password for a specific server
+# SHS_SERVERS__*__AUTH__TOKEN - Token for a specific server
+# SHS_SERVERS__*__VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
+# SHS_SERVERS__*__EMR_CLUSTER_ARN - EMR cluster ARN for a specific server

--- a/deploy/kubernetes/helm/mcp-apache-spark-history-server/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/mcp-apache-spark-history-server/templates/configmap.yaml
@@ -8,8 +8,7 @@ metadata:
 data:
   config.yaml: |
     mcp:
-      transports:
-        - streamable-http
+      transport: streamable-http
       port: "{{ .Values.config.port }}"
       debug: {{ .Values.config.debug }}
       address: 0.0.0.0

--- a/examples/aws/emr/README.md
+++ b/examples/aws/emr/README.md
@@ -44,7 +44,7 @@ If you need to access an EMR Spark History Server running in private subnets:
 ssh -AL 8157:localhost:8157 ec2-user@YOUR_BASTION_DNS -t ssh -ND 8157 hadoop@YOUR_PRIMARY_NODE_PRIVATE_DNS
 
 # Use the tool with proxy enabled
-SHS_SERVERS_LOCAL_URL=http://YOUR_PRIMARY_NODE_PRIVATE_DNS:18080 USE_PROXY=1 task start-mcp
+SHS_SERVERS__LOCAL__URL=http://YOUR_PRIMARY_NODE_PRIVATE_DNS:18080 USE_PROXY=1 task start-mcp
 ```
 
 **Note**: When configuring an EMR cluster ARN, the MCP server will automatically check for an existing Persistent UI. If one does not exist, it will create a new Persistent UI for the specified cluster. If a Persistent UI already exists, the server will use the existing one. This creation happens automatically during server initialization to enable Spark History Server access.

--- a/examples/integrations/claude-desktop/README.md
+++ b/examples/integrations/claude-desktop/README.md
@@ -45,7 +45,7 @@ curl http://localhost:18080/api/v1/applications
                 "spark-mcp",
             ],
             "env": {
-                "SHS_MCP_TRANSPORT": "stdio"
+                "SHS_MCP__TRANSPORT": "stdio"
             }
         }
     }
@@ -140,8 +140,7 @@ servers:
     default: true
     url: "http://localhost:18080"
 mcp:
-  transports:
-    - stdio
+  transport: "stdio"
 ```
 
 2. **Add MCP server**

--- a/examples/integrations/claude-desktop/claude-desktop-shs-mcp-config.json
+++ b/examples/integrations/claude-desktop/claude-desktop-shs-mcp-config.json
@@ -10,7 +10,7 @@
                 "spark_history_mcp.core.main"
             ],
             "env": {
-                "SHS_MCP_TRANSPORT": "stdio"
+                "SHS_MCP__TRANSPORT": "stdio"
             }
         }
     }

--- a/examples/integrations/kiro/README.md
+++ b/examples/integrations/kiro/README.md
@@ -51,7 +51,7 @@ Create or edit the Kiro MCP configuration file at `.kiro/settings/mcp.json` in y
       "command": "uvx",
       "args": ["--from", "mcp-apache-spark-history-server", "spark-mcp"],
       "env": {
-        "SHS_MCP_TRANSPORT": "stdio"
+        "SHS_MCP__TRANSPORT": "stdio"
       },
       "disabled": false,
       "autoApprove": []

--- a/src/spark_history_mcp/config/config.py
+++ b/src/spark_history_mcp/config/config.py
@@ -1,7 +1,8 @@
 import logging
 import os
+import warnings
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple
 
 import yaml
 from pydantic import Field
@@ -17,6 +18,45 @@ logger = logging.getLogger(__name__)
 # Per-user config lives at ~/.config/spark-mcp/config.yaml.
 DEFAULT_CONFIG_FILENAME = "config.yaml"
 APP_CONFIG_DIR = "spark-mcp"
+ENV_VAR_PREFIX = "SHS_"
+
+# Legacy single-underscore SHS_* env vars are deprecated in favor of the
+# double-underscore (__) delimiter.
+
+# Direct-read vars (not Config fields); excluded from delimiter detection.
+_DIRECT_READ_VARS = frozenset({"SHS_MCP_CONFIG", "SHS_MCP_TRANSPORT"})
+
+
+def _warn_legacy_env(names: List[str]) -> None:
+    message = (
+        "Single-underscore SHS_* environment variables are deprecated and will "
+        "be removed in a future major release; use the double-underscore (__) "
+        f"delimiter instead. In use: {', '.join(names)}"
+    )
+    warnings.warn(message, DeprecationWarning, stacklevel=2)
+    logger.warning(message)
+
+
+def _legacy_config_vars() -> List[str]:
+    """SHS_* config vars (excluding direct-read vars) using a single underscore."""
+    return [
+        env
+        for env in os.environ
+        if env.startswith(ENV_VAR_PREFIX)
+        and env not in _DIRECT_READ_VARS
+        and "__" not in env
+    ]
+
+
+def legacy_env_mode() -> bool:
+    for env in os.environ:
+        if (
+            env.startswith(ENV_VAR_PREFIX)
+            and env not in _DIRECT_READ_VARS
+            and "__" not in env
+        ):
+            return True
+    return False
 
 
 def user_config_path() -> str:
@@ -132,9 +172,14 @@ class TransportSecurityConfig(BaseSettings):
 class McpConfig(BaseSettings):
     """Configuration for the MCP server."""
 
-    transports: List[Literal["stdio", "sse", "streamable-http"]] = Field(
-        default_factory=lambda: ["streamable-http"]
-    )
+    transport: Optional[Literal["stdio", "streamable-http"]] = None
+    transports: Annotated[
+        Optional[List[Literal["stdio", "streamable-http"]]],
+        Field(
+            default=None,
+            deprecated="mcp.transports is deprecated; use the singular mcp.transport instead.",
+        ),
+    ]
     address: Optional[str] = "localhost"
     port: Optional[int | str] = "18888"
     debug: Optional[bool] = False
@@ -151,10 +196,10 @@ class Config(BaseSettings):
     servers: Dict[str, ServerConfig] = {
         "local": ServerConfig(url="http://localhost:18080", default=True),
     }
-    mcp: Optional[McpConfig] = McpConfig(transports=["streamable-http"])
+    mcp: Optional[McpConfig] = McpConfig()
     model_config = SettingsConfigDict(
-        env_prefix="SHS_",
-        env_nested_delimiter="_",
+        env_prefix=ENV_VAR_PREFIX,
+        env_nested_delimiter="__",
         env_file=".env",
         env_file_encoding="utf-8",
     )
@@ -181,3 +226,22 @@ class Config(BaseSettings):
             init_settings,
             file_secret_settings,
         )
+
+
+class LegacyConfig(Config):
+    """Config parsed with the deprecated single-underscore nesting delimiter."""
+
+    model_config = SettingsConfigDict(
+        env_prefix=ENV_VAR_PREFIX,
+        env_nested_delimiter="_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+
+
+def load_config() -> Config:
+    """Build the configuration, falling back to the legacy delimiter when in use."""
+    if legacy_env_mode():
+        _warn_legacy_env(_legacy_config_vars())
+        return LegacyConfig()
+    return Config()

--- a/src/spark_history_mcp/core/app.py
+++ b/src/spark_history_mcp/core/app.py
@@ -11,7 +11,7 @@ from mcp.server.transport_security import TransportSecuritySettings
 
 from spark_history_mcp.api.emr_persistent_ui_client import EMRPersistentUIClient
 from spark_history_mcp.api.spark_client import SparkRestClient
-from spark_history_mcp.config.config import Config
+from spark_history_mcp.config.config import Config, load_config
 
 from ..utils.utils import ApplicationDiscovery
 
@@ -31,8 +31,7 @@ class AppContext:
 
 @asynccontextmanager
 async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
-    # Config() automatically loads from SHS_MCP_CONFIG env var (set in main.py)
-    config = Config()
+    config = load_config()
 
     clients: dict[str, SparkRestClient] = {}
     default_client = None
@@ -104,7 +103,16 @@ def run(config: Config):
             allowed_origins=ts_config.allowed_origins,
         )
 
-    mcp.run(transport=os.getenv("SHS_MCP_TRANSPORT", config.mcp.transports[0]))
+    mcp_cfg = config.mcp
+    transport = os.getenv("SHS_MCP_TRANSPORT") or mcp_cfg.transport
+    if (
+        not transport
+        and "transports" in mcp_cfg.model_fields_set
+        and mcp_cfg.transports
+    ):
+        transport = mcp_cfg.transports[0]
+    transport = transport or "streamable-http"
+    mcp.run(transport=transport)
 
 
 mcp = FastMCP("Spark Events", lifespan=app_lifespan)

--- a/src/spark_history_mcp/core/main.py
+++ b/src/spark_history_mcp/core/main.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 
-from spark_history_mcp.config.config import Config, resolve_config_path
+from spark_history_mcp.config.config import load_config, resolve_config_path
 from spark_history_mcp.core import app
 
 # Configure logging
@@ -47,8 +47,7 @@ def main():
                 "No config file found; using built-in defaults and SHS_* env vars"
             )
 
-        # Now Config() will automatically load using the resolution cascade
-        config = Config()
+        config = load_config()
         if config.mcp.debug:
             logger.setLevel(logging.DEBUG)
         logger.debug(json.dumps(json.loads(config.model_dump_json()), indent=4))

--- a/tests/config-e2e.yaml
+++ b/tests/config-e2e.yaml
@@ -8,8 +8,7 @@ servers:
     url: "http://localhost:18080"
 
 mcp:
-  transports:
-    - streamable-http
+  transport: "streamable-http"
   port: "18888"
   debug: true
   address: localhost

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -1,3 +1,8 @@
+import os
+import socket
+import subprocess
+import sys
+import time
 from contextlib import AsyncExitStack, asynccontextmanager
 from types import TracebackType
 
@@ -901,3 +906,90 @@ async def test_list_stage_task_failures_not_found():
             {"app_id": app1_id, "stage_id": 999999},
         )
         assert result.isError
+
+
+# Spark History Server backing the e2e corpus (started by `task cli:start-shs`).
+shs_url = "http://localhost:18080"
+
+
+def _wait_for_port(host, port, timeout=30.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(1.0)
+            if sock.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.5)
+    return False
+
+
+@asynccontextmanager
+async def _mcp_client_at(endpoint):
+    async with AsyncExitStack() as stack:
+        read, write, _ = await stack.enter_async_context(
+            streamable_http_client(endpoint)
+        )
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        yield session
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_underscore_env_vars_still_work(tmp_path):
+    """A server configured entirely with deprecated single-underscore SHS_* env
+    vars still starts, serves, and warns about the deprecation.
+
+    SHS_MCP_PORT proves the value was applied (the server listens on that port)
+    and SHS_SERVERS_LOCAL_URL proves the configured Spark History Server is
+    reached (the e2e corpus comes back).
+    """
+    # Drop every SHS_* var the harness set, then configure exclusively through
+    # the legacy single-underscore form. This dict is the child's env only; the
+    # pytest process environment is never modified.
+
+    # A distinct port so the legacy-config server never clashes with the harness.
+    legacy_mcp_port = 18899
+    legacy_mcp_endpoint = f"http://localhost:{legacy_mcp_port}/mcp/"
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("SHS_")}
+    env["SHS_MCP_TRANSPORT"] = "streamable-http"
+    env["SHS_MCP_PORT"] = str(legacy_mcp_port)
+    env["SHS_MCP_ADDRESS"] = "localhost"
+    env["SHS_SERVERS_LOCAL_URL"] = shs_url
+    env["SHS_SERVERS_LOCAL_DEFAULT"] = "true"
+
+    log_path = tmp_path / "legacy-mcp.log"
+    with open(log_path, "w") as log_file:
+        proc = subprocess.Popen(  # noqa: S603  # fully controlled command
+            [sys.executable, "-m", "spark_history_mcp.core.main"],
+            env=env,
+            cwd=tmp_path,  # avoid discovering any ./config.yaml in the repo
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
+        try:
+            assert _wait_for_port("localhost", legacy_mcp_port), (
+                "server did not start on the port from SHS_MCP_PORT; log:\n"
+                + log_path.read_text()
+            )
+            # Listening on legacy_mcp_port proves SHS_MCP_PORT was honored.
+            async with _mcp_client_at(legacy_mcp_endpoint) as client:
+                result = await client.call_tool("list_applications", {})
+                assert not result.isError
+                apps = [Application.model_validate_json(c.text) for c in result.content]
+                by_id = {a.id: a.name for a in apps}
+                # SHS_SERVERS_LOCAL_URL routed to the e2e corpus.
+                assert by_id.get(app1_id) == "shs-e2e-app1"
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=10)
+
+    log = log_path.read_text()
+    # The deprecation warning fired and named the legacy variables in use.
+    assert "deprecated" in log.lower()
+    assert "SHS_MCP_PORT" in log
+    assert "SHS_SERVERS_LOCAL_URL" in log

--- a/tests/emr/test_emr_integration.py
+++ b/tests/emr/test_emr_integration.py
@@ -47,7 +47,7 @@ class TestEMRIntegration(unittest.TestCase):
         spark_client._api.list_applications.assert_called_once()
 
     @patch("spark_history_mcp.core.app.EMRPersistentUIClient")
-    @patch("spark_history_mcp.core.app.Config")
+    @patch("spark_history_mcp.core.app.load_config")
     def test_app_lifespan_with_emr_config(
         self, mock_config_class, mock_emr_client_class
     ):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -31,7 +31,7 @@ class TestConfig(unittest.TestCase):
             "mcp": {
                 "address": "test_host",
                 "port": 9999,
-                "transports": ["streamable-http", "sse"],
+                "transport": "streamable-http",
                 "debug": False,
             },
         }
@@ -51,9 +51,7 @@ class TestConfig(unittest.TestCase):
             # Verify the loaded configuration
             self.assertEqual(config.mcp.address, "test_host")
             self.assertEqual(config.mcp.port, 9999)
-            self.assertEqual(len(config.mcp.transports), 2)
-            self.assertIn("streamable-http", config.mcp.transports)
-            self.assertIn("sse", config.mcp.transports)
+            self.assertEqual(config.mcp.transport, "streamable-http")
             self.assertFalse(config.mcp.debug)
 
             # Verify server config
@@ -77,21 +75,22 @@ class TestConfig(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "SHS_MCP_ADDRESS": "env_host",
-            "SHS_MCP_PORT": "8888",
-            "SHS_MCP_DEBUG": "true",
-            "SHS_SERVERS_ENVSERVER_URL": "http://env-server:18080",
-            "SHS_SERVERS_ENVSERVER_AUTH_USERNAME": "env_user",
-            "SHS_SERVERS_ENVSERVER_AUTH_PASSWORD": "env_pass",
-            "SHS_SERVERS_ENVSERVER_DEFAULT": "true",
+            "SHS_MCP__ADDRESS": "env_host",
+            "SHS_MCP__PORT": "8888",
+            "SHS_MCP__DEBUG": "true",
+            "SHS_SERVERS__ENVSERVER__URL": "http://env-server:18080",
+            "SHS_SERVERS__ENVSERVER__AUTH__USERNAME": "env_user",
+            "SHS_SERVERS__ENVSERVER__AUTH__PASSWORD": "env_pass",
+            "SHS_SERVERS__ENVSERVER__DEFAULT": "true",
         },
     )
     def test_config_from_env_vars(self):
         """Test loading configuration from environment variables.
 
-        Note: server names must not contain underscores because the settings
-        env_nested_delimiter is '_'. ``SHS_SERVERS_ENVSERVER_URL`` maps to
-        ``servers.envserver.url``.
+        Nesting levels are separated by a double underscore (``__``), so
+        ``SHS_SERVERS__ENVSERVER__URL`` maps to ``servers.envserver.url``.
+        Because ``__`` (not a single ``_``) delimits levels, both field names
+        and server names may themselves contain single underscores.
         """
         # Create minimal config with empty servers dict to be populated from env
         minimal_config = {"servers": {}}
@@ -122,10 +121,51 @@ class TestConfig(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
-            "SHS_MCP_ADDRESS": "override_host",
-            "SHS_MCP_PORT": "7777",
-            "SHS_SERVERS_TESTSERVER_URL": "http://override-server:18080",
-            "SHS_SERVERS_TESTSERVER_AUTH_USERNAME": "override_user",
+            "SHS_SERVERS__MY_PROD_SERVER__URL": "http://prod-server:18080",
+            "SHS_SERVERS__MY_PROD_SERVER__AUTH__USERNAME": "prod_user",
+            "SHS_SERVERS__MY_PROD_SERVER__VERIFY_SSL": "false",
+            "SHS_SERVERS__MY_PROD_SERVER__EMR_CLUSTER_ARN": "arn:aws:emr:us-east-1:123:cluster/j-ABC",
+            "SHS_SERVERS__MY_PROD_SERVER__DEFAULT": "true",
+        },
+    )
+    def test_env_vars_server_name_with_underscores(self):
+        """Server names and underscore-containing fields resolve via the ``__`` delimiter.
+
+        This is the primary benefit of using ``__`` instead of ``_``:
+        ``SHS_SERVERS__MY_PROD_SERVER__URL`` unambiguously maps to
+        ``servers.my_prod_server.url`` even though both the server name
+        (``my_prod_server``) and the fields (``verify_ssl``,
+        ``emr_cluster_arn``) contain single underscores.
+        """
+        minimal_config = {"servers": {}}
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            yaml.dump(minimal_config, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            with patch.dict(os.environ, {"SHS_MCP_CONFIG": temp_file_path}):
+                config = Config()
+
+            self.assertIn("my_prod_server", config.servers)
+            server = config.servers["my_prod_server"]
+            self.assertEqual(server.url, "http://prod-server:18080")
+            self.assertEqual(server.auth.username, "prod_user")
+            self.assertFalse(server.verify_ssl)
+            self.assertEqual(
+                server.emr_cluster_arn, "arn:aws:emr:us-east-1:123:cluster/j-ABC"
+            )
+            self.assertTrue(server.default)
+        finally:
+            os.unlink(temp_file_path)
+
+    @patch.dict(
+        os.environ,
+        {
+            "SHS_MCP__ADDRESS": "override_host",
+            "SHS_MCP__PORT": "7777",
+            "SHS_SERVERS__TESTSERVER__URL": "http://override-server:18080",
+            "SHS_SERVERS__TESTSERVER__AUTH__USERNAME": "override_user",
         },
     )
     def test_env_vars_override_file_config(self):
@@ -168,7 +208,6 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(config.mcp.address, "localhost")
             self.assertEqual(config.mcp.port, "18888")
             self.assertFalse(config.mcp.debug)
-            self.assertEqual(config.mcp.transports, ["streamable-http"])
 
             # Check server defaults
             server = config.servers["minimal"]


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This makes `__` the env var delimiter  instead of current `_`. It also deprecates the transports field in favor of transport field.

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

