### PR TITLE
Support custom CAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ servers:
       username: "user"
       password: "pass"
     include_plan_description: false   # include SQL plans by default (default: false)
+
 mcp:
   transport: "streamable-http"   # or: stdio
   port: "18888"
@@ -189,6 +190,7 @@ SHS_SERVERS__*__AUTH__USERNAME
 SHS_SERVERS__*__AUTH__PASSWORD
 SHS_SERVERS__*__AUTH__TOKEN
 SHS_SERVERS__*__VERIFY_SSL
+SHS_SERVERS__*__SSL_CA_CERT    Path to a PEM CA bundle for a specific server
 SHS_SERVERS__*__TIMEOUT
 SHS_SERVERS__*__EMR_CLUSTER_ARN
 SHS_SERVERS__*__INCLUDE_PLAN_DESCRIPTION
@@ -213,6 +215,21 @@ servers:
 Agents can target a specific server per query:
 
 > *"Get application `<app_id>` from the production server"*
+
+### Custom CA bundle
+
+For a private CA or TLS-inspecting proxy, keep `verify_ssl: true` and point
+`ssl_ca_cert` to a mounted PEM bundle:
+
+```yaml
+servers:
+  local:
+    ssl_ca_cert: "/etc/ssl/custom-ca/ca-bundle.pem"
+```
+
+Set the same path with `SHS_SERVERS__LOCAL__SSL_CA_CERT`. The CA certificates
+in the bundle are added to the container's default trust roots, so include the
+issuing CA and intermediates.
 
 ## 🏗️ Architecture
 

--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,8 @@ servers:
   # production:
   #   url: "https://spark-history.company.com:18080"
   #   verify_ssl: true
+  #   # Path inside the process/container to a PEM bundle for a private CA.
+  #   ssl_ca_cert: "/etc/ssl/custom-ca/ca-bundle.pem"
   #   auth:
       # Use environment variables for production
       # username: ${SHS_SERVERS__PRODUCTION__AUTH__USERNAME}
@@ -79,4 +81,5 @@ mcp:
 # SHS_SERVERS__*__AUTH__PASSWORD - Password for a specific server
 # SHS_SERVERS__*__AUTH__TOKEN - Token for a specific server
 # SHS_SERVERS__*__VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
+# SHS_SERVERS__*__SSL_CA_CERT - Path to a PEM CA bundle for a specific server
 # SHS_SERVERS__*__EMR_CLUSTER_ARN - EMR cluster ARN for a specific server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,11 @@ classifiers = [
 dependencies = [
     "mcp[cli]~=1.26",
     "pyyaml~=6.0",
-    "requests~=2.32",
+    "requests>=2.32.3,<3.0",
     "pydantic~=2.12",
     "boto3~=1.42",
     "pydantic-settings~=2.13",
-    "requests[socks]~=2.32",
+    "requests[socks]>=2.32.3,<3.0",
     "pysocks~=1.7",
     "mcp-proxy-for-aws>=1.0,<2.0"
 ]

--- a/src/spark_history_mcp/api/emr_persistent_ui_client.py
+++ b/src/spark_history_mcp/api/emr_persistent_ui_client.py
@@ -6,6 +6,7 @@ an authenticated HTTP session (cookie-based) for Spark History Server access.
 """
 
 import logging
+import ssl
 import time
 from contextlib import contextmanager
 from typing import Dict, Optional, Tuple
@@ -14,6 +15,7 @@ from urllib.parse import urlparse
 import boto3
 import requests
 from botocore.exceptions import ClientError
+from requests.adapters import HTTPAdapter
 
 from spark_history_mcp.config.config import ServerConfig
 
@@ -21,6 +23,24 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
+
+
+class _CustomCAAdapter(HTTPAdapter):
+    """Use an SSL context containing default and configured CA roots."""
+
+    def __init__(self, ssl_context: ssl.SSLContext):
+        self._ssl_context = ssl_context
+        super().__init__()
+
+    def build_connection_pool_key_attributes(self, request, verify, cert=None):
+        host_params, pool_kwargs = super().build_connection_pool_key_attributes(
+            request, verify, cert
+        )
+        if verify is not False:
+            pool_kwargs.pop("ca_certs", None)
+            pool_kwargs.pop("ca_cert_dir", None)
+            pool_kwargs["ssl_context"] = self._ssl_context
+        return host_params, pool_kwargs
 
 
 @contextmanager
@@ -46,6 +66,12 @@ class EMRPersistentUIClient:
         self.emr_client = boto3.client("emr", region_name=self.region)
 
         self.session = requests.Session()
+        if not server_config.verify_ssl:
+            self.session.verify = False
+        elif server_config.ssl_ca_cert:
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(cafile=server_config.ssl_ca_cert)
+            self.session.mount("https://", _CustomCAAdapter(ssl_context))
         self.persistent_ui_id: Optional[str] = None
         self.presigned_url: Optional[str] = None
         self.base_url: Optional[str] = None

--- a/src/spark_history_mcp/api/spark_client.py
+++ b/src/spark_history_mcp/api/spark_client.py
@@ -106,6 +106,7 @@ class SparkRestClient:
         self.base_url = self.config.url.rstrip("/") + "/api/v1"
         self.use_proxy = self.config.use_proxy
         self.verify_ssl = self.config.verify_ssl
+        self.ssl_ca_cert = self.config.ssl_ca_cert
         self.timeout = self.config.timeout
 
         # Optional callback returning a fresh Cookie header (EMR re-auth).
@@ -114,7 +115,11 @@ class SparkRestClient:
         self._api = self._build_api_client()
 
     def _build_api_client(self) -> DefaultApi:
-        configuration = Configuration(host=self.base_url, verify_ssl=self.verify_ssl)
+        configuration = Configuration(
+            host=self.base_url,
+            verify_ssl=self.verify_ssl,
+            ssl_ca_cert=self.ssl_ca_cert,
+        )
 
         # Keep "/" unescaped in path parameters so a composite application id
         # ("{base-app-id}/{attempt-id}") is sent as a real path, not "%2F".

--- a/src/spark_history_mcp/api_client/rest.py
+++ b/src/spark_history_mcp/api_client/rest.py
@@ -83,6 +83,12 @@ class RESTClientObject:
             "key_file": configuration.key_file,
             "ca_cert_data": configuration.ca_cert_data,
         }
+        if configuration.verify_ssl and configuration.ssl_ca_cert:
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(cafile=configuration.ssl_ca_cert)
+            pool_args["ssl_context"] = ssl_context
+            # The explicit context already contains the default and custom roots.
+            pool_args["ca_certs"] = None
         if configuration.assert_hostname is not None:
             pool_args['assert_hostname'] = (
                 configuration.assert_hostname

--- a/src/spark_history_mcp/config/config.py
+++ b/src/spark_history_mcp/config/config.py
@@ -137,6 +137,7 @@ class ServerConfig(BaseSettings):
     auth: AuthConfig = Field(default_factory=AuthConfig, exclude=True)
     default: bool = False
     verify_ssl: bool = True
+    ssl_ca_cert: Optional[str] = None
     emr_cluster_arn: Optional[str] = None  # EMR specific field
     use_proxy: bool = False
     timeout: int = 30  # HTTP request timeout in seconds

--- a/tests/emr/test_emr_integration.py
+++ b/tests/emr/test_emr_integration.py
@@ -3,6 +3,8 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+import requests
+
 # Add root directory to Python path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 from spark_history_mcp.api.emr_persistent_ui_client import EMRPersistentUIClient
@@ -45,6 +47,43 @@ class TestEMRIntegration(unittest.TestCase):
         spark_client._api.list_applications.return_value = []
         self.assertEqual(spark_client.list_applications(), [])
         spark_client._api.list_applications.assert_called_once()
+
+    @patch("spark_history_mcp.api.emr_persistent_ui_client.ssl.create_default_context")
+    @patch("spark_history_mcp.api.emr_persistent_ui_client.boto3.client")
+    def test_emr_session_appends_custom_ca_bundle(
+        self, mock_boto_client, mock_create_default_context
+    ):
+        """The pre-signed URL session appends the configured CA to default roots."""
+        ssl_context = MagicMock()
+        mock_create_default_context.return_value = ssl_context
+        client = EMRPersistentUIClient(
+            ServerConfig(
+                emr_cluster_arn=self.emr_cluster_arn,
+                ssl_ca_cert="/etc/ssl/custom-ca/ca-bundle.pem",
+            )
+        )
+
+        ssl_context.load_verify_locations.assert_called_once_with(
+            cafile="/etc/ssl/custom-ca/ca-bundle.pem"
+        )
+        adapter = client.session.get_adapter("https://example.com")
+        self.assertIs(adapter._ssl_context, ssl_context)
+        request = requests.Request("GET", "https://example.com").prepare()
+        _, pool_args = adapter.build_connection_pool_key_attributes(request, True)
+        self.assertIs(pool_args["ssl_context"], ssl_context)
+        self.assertNotIn("ca_certs", pool_args)
+        self.assertTrue(client.session.verify)
+        mock_boto_client.assert_called_once_with("emr", region_name="us-east-1")
+
+    @patch("spark_history_mcp.api.emr_persistent_ui_client.boto3.client")
+    def test_emr_session_honors_verify_ssl_false(self, mock_boto_client):
+        """The pre-signed URL session matches the configured TLS verification mode."""
+        client = EMRPersistentUIClient(
+            ServerConfig(emr_cluster_arn=self.emr_cluster_arn, verify_ssl=False)
+        )
+
+        self.assertFalse(client.session.verify)
+        mock_boto_client.assert_called_once_with("emr", region_name="us-east-1")
 
     @patch("spark_history_mcp.core.app.EMRPersistentUIClient")
     @patch("spark_history_mcp.core.app.load_config")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -26,6 +26,7 @@ class TestConfig(unittest.TestCase):
                     "auth": {"username": "test_user", "password": "test_pass"},
                     "default": True,
                     "verify_ssl": True,
+                    "ssl_ca_cert": "/etc/ssl/custom-ca/ca-bundle.pem",
                 }
             },
             "mcp": {
@@ -62,6 +63,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(server.auth.password, "test_pass")
             self.assertTrue(server.default)
             self.assertTrue(server.verify_ssl)
+            self.assertEqual(server.ssl_ca_cert, "/etc/ssl/custom-ca/ca-bundle.pem")
         finally:
             # Clean up the temporary file
             os.unlink(temp_file_path)
@@ -124,6 +126,7 @@ class TestConfig(unittest.TestCase):
             "SHS_SERVERS__MY_PROD_SERVER__URL": "http://prod-server:18080",
             "SHS_SERVERS__MY_PROD_SERVER__AUTH__USERNAME": "prod_user",
             "SHS_SERVERS__MY_PROD_SERVER__VERIFY_SSL": "false",
+            "SHS_SERVERS__MY_PROD_SERVER__SSL_CA_CERT": "/etc/ssl/custom-ca/ca-bundle.pem",
             "SHS_SERVERS__MY_PROD_SERVER__EMR_CLUSTER_ARN": "arn:aws:emr:us-east-1:123:cluster/j-ABC",
             "SHS_SERVERS__MY_PROD_SERVER__DEFAULT": "true",
         },
@@ -152,6 +155,7 @@ class TestConfig(unittest.TestCase):
             self.assertEqual(server.url, "http://prod-server:18080")
             self.assertEqual(server.auth.username, "prod_user")
             self.assertFalse(server.verify_ssl)
+            self.assertEqual(server.ssl_ca_cert, "/etc/ssl/custom-ca/ca-bundle.pem")
             self.assertEqual(
                 server.emr_cluster_arn, "arn:aws:emr:us-east-1:123:cluster/j-ABC"
             )

--- a/tests/unit/test_spark_client.py
+++ b/tests/unit/test_spark_client.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from spark_history_mcp.api.spark_client import AttemptRequiredError, SparkRestClient
 from spark_history_mcp.api_client.exceptions import (
@@ -184,6 +184,26 @@ class TestSparkRestClient(unittest.TestCase):
 
         with self.assertRaises(NotFoundException):
             self.client.list_jobs("app-123")
+
+    @patch("spark_history_mcp.api_client.rest.ssl.create_default_context")
+    def test_custom_ca_bundle_configuration(self, mock_create_default_context):
+        ssl_context = MagicMock()
+        mock_create_default_context.return_value = ssl_context
+        client = SparkRestClient(
+            ServerConfig(
+                url="https://spark-history-server:18080",
+                ssl_ca_cert="/etc/ssl/custom-ca/ca-bundle.pem",
+            )
+        )
+        configuration = client._api.api_client.configuration
+        self.assertTrue(configuration.verify_ssl)
+        self.assertEqual(configuration.ssl_ca_cert, "/etc/ssl/custom-ca/ca-bundle.pem")
+        ssl_context.load_verify_locations.assert_called_once_with(
+            cafile="/etc/ssl/custom-ca/ca-bundle.pem"
+        )
+        pool_args = client._api.api_client.rest_client.pool_manager.connection_pool_kw
+        self.assertIs(pool_args["ssl_context"], ssl_context)
+        self.assertIsNone(pool_args["ca_certs"])
 
     def test_proxy_configuration(self):
         client = SparkRestClient(

--- a/uv.lock
+++ b/uv.lock
@@ -1009,8 +1009,8 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "~=2.13" },
     { name = "pysocks", specifier = "~=1.7" },
     { name = "pyyaml", specifier = "~=6.0" },
-    { name = "requests", specifier = "~=2.32" },
-    { name = "requests", extras = ["socks"], specifier = "~=2.32" },
+    { name = "requests", specifier = ">=2.32.3,<3.0" },
+    { name = "requests", extras = ["socks"], specifier = ">=2.32.3,<3.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This adds support for custom CAs in our clients to address use cases where the system default CA bundle does not contain the CA chain used to sign the endpoint cert.

fixes #215

## 🎯 Type of Change
<!-- Mark with [x] -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

